### PR TITLE
make dependency on openapi3-ts package work out of the box

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi3-ts",
   "version": "0.1.1",
   "description": "TS Model & utils for OpenAPI 3.0.x specification.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/metadevpro/openapi3-ts.git"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "TS Model & utils for OpenAPI 3.0.x specification.",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/metadevpro/openapi3-ts.git"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declaration": true,
     "target": "ES6",
     "module": "commonjs",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
First of all, this project is awesome and super valuable to upcoming https://github.com/Azure/autorest/ development. 🎉 

When taking a dependency on your package from my test project (TypeScript), I encountered 2 little issues:
- tsc couldn't find types to the stuff in `dist` (since it doesn't randomly search for matching `.ts` files)
- the `package.json` was pointing to the wrong spot (and obviously didn't point to the declaration files)

I've fixed both issues below, would be awesome if you could republish the package on npm accordingly 🙂 