### PR TITLE
Make info version property required as per OA3 spec

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -8,7 +8,8 @@ describe("OpenApiBuilder", () => {
         expect(OpenApiBuilder.create().getSpec()).eql({
             openapi: "3.0.0",
             info: {
-                title: "app"
+                title: "app",
+                version: "version"
             },
             paths:  {},
             components:  {

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -14,7 +14,8 @@ export class OpenApiBuilder {
         this.rootDoc = {
             openapi: "3.0.0",
             info: {
-                title: "app"
+                title: "app",
+                version: "version"
             },
             paths:  {},
             components:  {

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -19,7 +19,7 @@ export interface InfoObject extends ISpecificationExtension {
     termsOfService?: string;
     contact?: ContactObject;
     license?: LicenseObject;
-    version?: string;
+    version: string;
 }
 export interface ContactObject extends ISpecificationExtension {
     name: string;
@@ -240,4 +240,3 @@ export interface ScopesObject extends ISpecificationExtension {
 export interface SecurityRequirementObject {
     [name: string]: [string];
 }
-


### PR DESCRIPTION
As per [the OpenAPI 3 spec](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc0/versions/3.0.md#infoObject), the `version` property within the `info` object should be required. This PR addresses that.