### PR TITLE
Adjust typings to better match the spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "rimraf dist && npm run lint && tsc -p tsconfig.json",
     "build:w": "tsc -p tsconfig.json -w",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
+    "prepublish": "npm run build",
     "test:tdd": "mocha --recursive --reporter min --compilers ts:ts-node/register --require source-map-support/register \"src/**/*.spec.ts\" --watch",
     "test": "mocha --recursive --compilers ts:ts-node/register --require source-map-support/register \"src/**/*.spec.ts\"",
     "cover": "nyc npm test"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "rimraf dist && npm run lint && tsc -p tsconfig.json",
     "build:w": "tsc -p tsconfig.json -w",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test:tdd": "mocha --recursive --reporter min --compilers ts:ts-node/register --require source-map-support/register \"src/**/*.spec.ts\" --watch",
     "test": "mocha --recursive --compilers ts:ts-node/register --require source-map-support/register \"src/**/*.spec.ts\"",
     "cover": "nyc npm test"

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -90,7 +90,7 @@ export interface ExternalDocumentationObject extends ISpecificationExtension {
 }
 export interface ParameterObject extends ISpecificationExtension {
     name: string;
-    in: "query" | "header" | "path" | "cookie";
+    in: string; // "query" | "header" | "path" | "cookie";
     description?: string;
     required?: boolean;
     deprecated?: boolean;

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -76,8 +76,8 @@ export interface OperationObject extends ISpecificationExtension {
     description?: string;
     externalDocs?: ExternalDocumentationObject;
     operationId?: string;
-    parameters?: [ ParameterObject | ReferenceObject ];
-    requestBody?: [ RequestBodyObject | ReferenceObject ];
+    parameters?: (ParameterObject | ReferenceObject)[];
+    requestBody?: RequestBodyObject | ReferenceObject;
     responses: ResponsesObject;
     callbacks?: CallbacksObject;
     deprecated?: boolean;
@@ -90,7 +90,7 @@ export interface ExternalDocumentationObject extends ISpecificationExtension {
 }
 export interface ParameterObject extends ISpecificationExtension {
     name: string;
-    in: string; // "query" | "header" | "path" | "cookie";
+    in: "query" | "header" | "path" | "cookie";
     description?: string;
     required?: boolean;
     deprecated?: boolean;
@@ -100,7 +100,7 @@ export interface ParameterObject extends ISpecificationExtension {
     explode?: boolean;
     allowReserved?: boolean;
     schema?: SchemaObject | ReferenceObject;
-    examples?: [ ExampleObject | ReferenceObject ];
+    examples?: { [param: string]: ExampleObject | ReferenceObject };
     example?: ExampleObject | ReferenceObject;
     content?: ContentObject;
 }
@@ -131,7 +131,7 @@ export interface EncodingPropertyObject {
     [key: string]: any;   // (any) = Hack for allowing ISpecificationExtension
 }
 export interface ResponsesObject extends ISpecificationExtension {
-    default: ResponseObject | ReferenceObject;
+    default?: ResponseObject | ReferenceObject;
 
     // [statuscode: string]: ResponseObject | ReferenceObject;
     [statuscode: string]: ResponseObject | ReferenceObject | any;   // (any) = Hack for allowing ISpecificationExtension


### PR DESCRIPTION
Hi, thanks for a great library! I'm using it mainly for the really helpful spec typings. Here are fixes for a couple of discrepancies I stumbled upon:

- `OperationObject.parameters` to a union array type instead of the tuple to allow e.g. something like `ParameterObject[]` as a value
- `OperationObject.requestBody` from a tuple to a union type `RequestBodyObject | ReferenceObject`
- `ParameterObject.examples` from a tuple to a string-indexed map as per the spec 
- `ParameterObject.in` from a string to a union type `"query" | "header" | "path" | "cookie"`
- `ResponsesObject.default` to optional

I also added a `prepare` npm script to allow installing via git URL.

Thanks!
