### PR TITLE
Fix additionalProperties type

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -226,7 +226,7 @@ export interface SchemaObject extends ISpecificationExtension {
     not?: SchemaObject | ReferenceObject;
     items?: SchemaObject | ReferenceObject;
     properties?: {[propertyName: string]: (SchemaObject | ReferenceObject)};
-    additionalProperties?: (SchemaObject | ReferenceObject)[];
+    additionalProperties?: (SchemaObject | ReferenceObject);
     description?: string;
     format?: string;
     default?: any;


### PR DESCRIPTION
hi @pjmolina Thank you for providing typescript interfaces of OAS3 specs in this module!

According to the OpenAPI-Specification, `additionalProperties` should be a boolean or object(refers to SchemaObject), but not an array of them.
See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject

> additionalProperties - Value can be boolean or object. Inline or referenced schema MUST be of a Schema Object and not a standard JSON Schema.