### PR TITLE
Changed SecurityRequirementObject to use string[] instead of [string]

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -269,5 +269,5 @@ export interface ScopesObject extends ISpecificationExtension {
     [scope: string]: any; // Hack for allowing ISpecificationExtension
 }
 export interface SecurityRequirementObject {
-    [name: string]: [string];
+    [name: string]: string[];
 }


### PR DESCRIPTION
The Security Requirements object should accept an array of strings (not just a single string).
See the [specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#security-requirement-object).
