### PR TITLE
Added missing properties to SchemaObject

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -230,6 +230,23 @@ export interface SchemaObject extends ISpecificationExtension {
     description?: string;
     format?: string;
     default?: any;
+
+    title?: string;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: boolean;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    required?: string[];
+    enum?: any[];
 }
 export interface DiscriminatorObject {
     propertyName: string;


### PR DESCRIPTION
Hi @pjmolina, thank you for this module, it help me understand the specs a lot.

According to the [Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject), Schema Object have some properties are "taken directly from the JSON Schema definition and follow the same specifications", which is not defined in SchemaObject.

Also see [JSON Schema Validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00) section 5 for detail definitions.