### PR TITLE
Cast "header" to ParameterLocation to avoid ts-node 6.x error

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -125,7 +125,7 @@ describe("OpenApiBuilder", () => {
     it("addParameter", () => {
         let par5 = {
             name: "id",
-            in:   "header",
+            in:   "header" as oa.ParameterLocation,
             schema: {
                 $ref: "#/components/schemas/id"
             }


### PR DESCRIPTION
This is really weird.  I see the following error from inside VSCode:
```
Argument of type '{ name: string; in: string; schema: { $ref: string; }; }' is not assignable to parameter of type 'ParameterObject'.
  Types of property 'in' are incompatible.
    Type 'string' is not assignable to type 'ParameterLocation'.
```

But TypeScript claims it's fixed by https://github.com/Microsoft/TypeScript/pull/10676