### PR TITLE
mark schema as required

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -118,7 +118,7 @@ export interface ParameterObject extends ISpecificationExtension {
     style?: string; // "matrix" | "label" | "form" | "simple" | "spaceDelimited" | "pipeDelimited" | "deepObject";
     explode?: boolean;
     allowReserved?: boolean;
-    schema?: SchemaObject | ReferenceObject;
+    schema: SchemaObject | ReferenceObject;
     examples?: { [param: string]: ExampleObject | ReferenceObject };
     example?: any;
     content?: ContentObject;


### PR DESCRIPTION
hi @pjmolina I think `schema` is a **required** field in `ParameterObject`, for example, define a parameter entry without `schema` in [swagger editor](https://editor.swagger.io/#), it throws error:

> Schema error at paths['/pets'].get.parameters[0]
should have required property 'schema'
missingProperty: schema
Jump to line 24

PTAL thanks!