### PR TITLE
servers property in all types is an array

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -98,7 +98,7 @@ export interface PathItemObject extends ISpecificationExtension {
     head?: OperationObject;
     patch?: OperationObject;
     trace?: OperationObject;
-    servers?: ServerObject;
+    servers?: ServerObject[];
     parameters?: (ParameterObject | ReferenceObject)[];
 }
 export interface OperationObject extends ISpecificationExtension {
@@ -113,7 +113,7 @@ export interface OperationObject extends ISpecificationExtension {
     callbacks?: CallbacksObject;
     deprecated?: boolean;
     security?: SecurityRequirementObject[];
-    servers?: ServerObject;
+    servers?: ServerObject[];
 }
 export interface ExternalDocumentationObject extends ISpecificationExtension {
     description?: string;


### PR DESCRIPTION
The `servers` property in **PathItemObject** and **OperationObject** is an array on `ServerObject`, similar to how it's in **OpenAPIObject**


See https://swagger.io/specification/#pathsObject