### PR TITLE
fix: boolean for SchemaObject#additionalProperties

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -263,7 +263,7 @@ export interface SchemaObject extends ISpecificationExtension {
     not?: SchemaObject | ReferenceObject;
     items?: SchemaObject | ReferenceObject;
     properties?: {[propertyName: string]: (SchemaObject | ReferenceObject)};
-    additionalProperties?: (SchemaObject | ReferenceObject);
+    additionalProperties?: (SchemaObject | ReferenceObject | boolean);
     description?: string;
     format?: string;
     default?: any;


### PR DESCRIPTION
Fix the type definition of SchmaObject to follow the spec
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#schema-object

> **additionalProperties**
> Value can be boolean or object. Inline or referenced schema MUST be of a Schema Object and not a standard JSON Schema.

@pjmolina could you please review?