### PR TITLE
Update SecuritySchema to match spec

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -315,8 +315,8 @@ export interface SecuritySchemeObject extends ISpecificationExtension {
     in?: string;                // required only for apiKey
     scheme?: string;            // required only for http
     bearerFormat?: string;
-    flow?: OAuthFlowObject;     // required only for oauth2
-    openIdConnectUrl?: string;  // required only for oauth2
+    flows?: OAuthFlowsObject;     // required only for oauth2
+    openIdConnectUrl?: string;  // required only for openIdConnect
 }
 export interface OAuthFlowsObject extends ISpecificationExtension {
     implicit?: OAuthFlowObject;

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -325,8 +325,8 @@ export interface OAuthFlowsObject extends ISpecificationExtension {
     authorizationCode?: OAuthFlowObject;
 }
 export interface OAuthFlowObject extends ISpecificationExtension {
-    authorizationUrl: string;
-    tokenUrl: string;
+    authorizationUrl?: string;
+    tokenUrl?: string;
     refreshUrl?: string;
     scopes: ScopesObject;
 }


### PR DESCRIPTION
Not sure if this was typo but according to spec the SecurityScheme should have a flows object instead of flow
https://swagger.io/docs/specification/authentication/