### PR TITLE
Separate header and parameter type definition

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -212,9 +212,7 @@ describe("OpenApiBuilder", () => {
     });
     it("addHeaders", () => {
         let h5: oa.HeaderObject = {
-            name: "h5",
-            description: "heaer 5",
-            in: "header"
+            description: "header 5"
         };
         let sut = OpenApiBuilder.create().addHeader("h5", h5).rootDoc;
         expect(sut.components.headers.h5).eql(h5);

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -144,9 +144,7 @@ export type ParameterStyle =
   | 'pipeDelimited'
   | 'deepObject';
 
-export interface ParameterObject extends ISpecificationExtension {
-    name: string;
-    in: ParameterLocation; // "query" | "header" | "path" | "cookie";
+export interface BaseParameterObject extends ISpecificationExtension {
     description?: string;
     required?: boolean;
     deprecated?: boolean;
@@ -159,6 +157,11 @@ export interface ParameterObject extends ISpecificationExtension {
     examples?: { [param: string]: ExampleObject | ReferenceObject };
     example?: any;
     content?: ContentObject;
+}
+
+export interface ParameterObject extends BaseParameterObject {
+    name: string;
+    in: ParameterLocation; // "query" | "header" | "path" | "cookie";
 }
 export interface RequestBodyObject extends ISpecificationExtension {
     description?: string;
@@ -231,7 +234,7 @@ export interface LinkObject extends ISpecificationExtension {
 export interface LinkParametersObject {
     [name: string]: any | string;
 }
-export interface HeaderObject extends ParameterObject {
+export interface HeaderObject extends BaseParameterObject {
 }
 export interface TagObject extends ISpecificationExtension {
     name: string;


### PR DESCRIPTION
Hello :)

As per the [OpenApi3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#headerObject) spec...

> The `Header` Object follows the structure of the `Parameter` Object with the following changes:
> - `name` MUST NOT be specified, it is given in the corresponding headers map.
> - `in` MUST NOT be specified, it is implicitly in header.

This PR addresses these two exceptions by creating a base type from which branch `ParameterObject` and `HeaderObject`, without coercing `HeaderObject` to have `name` and `in` required properties.

I've updated an associated test, happy to make more changes or amend the ones made to align with code style, etc.