### PR TITLE
fix references in components type definitions

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -166,9 +166,23 @@ describe("OpenApiBuilder", () => {
         let sut = OpenApiBuilder.create().addSchema("schema01", schema1).rootDoc;
         expect(sut.components.schemas.schema01).eql(schema1);
     });
+    it("addSchema reference", () => {
+        let schema1 = {
+            $ref: "#/components/schemas/id"
+        };
+        let sut = OpenApiBuilder.create().addSchema("schema01", schema1).rootDoc;
+        expect(sut.components.schemas.schema01).eql(schema1);
+    });
     it("addResponse", () => {
         let resp00 = {
             description: "object created"
+        };
+        let sut = OpenApiBuilder.create().addResponse("resp00", resp00).rootDoc;
+        expect(sut.components.responses.resp00).eql(resp00);
+    });
+    it("addResponse reference", () => {
+        let resp00 = {
+            $ref: "#/components/responses/reference"
         };
         let sut = OpenApiBuilder.create().addResponse("resp00", resp00).rootDoc;
         expect(sut.components.responses.resp00).eql(resp00);
@@ -184,10 +198,24 @@ describe("OpenApiBuilder", () => {
         let sut = OpenApiBuilder.create().addParameter("par5", par5).rootDoc;
         expect(sut.components.parameters.par5).eql(par5);
     });
+    it("addParameter reference", () => {
+        let par5 = {
+            $ref: "#/components/parameters/id"
+        };
+        let sut = OpenApiBuilder.create().addParameter("par5", par5).rootDoc;
+        expect(sut.components.parameters.par5).eql(par5);
+    });
     it("addExample", () => {
         let example4 = {
             a: "a desc",
             b: "a desc"
+        };
+        let sut = OpenApiBuilder.create().addExample("example4", example4).rootDoc;
+        expect(sut.components.examples.example4).eql(example4);
+    });
+    it("addExample reference", () => {
+        let example4 = {
+            $ref: "#/components/examples/id"
         };
         let sut = OpenApiBuilder.create().addExample("example4", example4).rootDoc;
         expect(sut.components.examples.example4).eql(example4);
@@ -210,9 +238,23 @@ describe("OpenApiBuilder", () => {
         let sut = OpenApiBuilder.create().addRequestBody("reqBody9", reqBody9).rootDoc;
         expect(sut.components.requestBodies.reqBody9).eql(reqBody9);
     });
+    it("addRequestBody reference", () => {
+        let reqBody9 = {
+            $ref: "#/components/requestBodies/id"
+        };
+        let sut = OpenApiBuilder.create().addRequestBody("reqBody9", reqBody9).rootDoc;
+        expect(sut.components.requestBodies.reqBody9).eql(reqBody9);
+    });
     it("addHeaders", () => {
         let h5: oa.HeaderObject = {
             description: "header 5"
+        };
+        let sut = OpenApiBuilder.create().addHeader("h5", h5).rootDoc;
+        expect(sut.components.headers.h5).eql(h5);
+    });
+    it("addHeaders Reference", () => {
+        let h5: oa.HeaderObject = {
+            $ref: "#/components/headers/id"
         };
         let sut = OpenApiBuilder.create().addHeader("h5", h5).rootDoc;
         expect(sut.components.headers.h5).eql(h5);
@@ -225,9 +267,23 @@ describe("OpenApiBuilder", () => {
         let sut = OpenApiBuilder.create().addSecurityScheme("sec7", sec7).rootDoc;
         expect(sut.components.securitySchemes.sec7).eql(sec7);
     });
+    it("addSecuritySchemes reference", () => {
+        let sec7 = {
+            $ref: "#/components/securitySchemes/id"
+        };
+        let sut = OpenApiBuilder.create().addSecurityScheme("sec7", sec7).rootDoc;
+        expect(sut.components.securitySchemes.sec7).eql(sec7);
+    });
     it("addLink", () => {
         let link0: oa.LinkObject = {
             href: "/users/10101110/department"
+        };
+        let sut = OpenApiBuilder.create().addLink("link0", link0).rootDoc;
+        expect(sut.components.links.link0).eql(link0);
+    });
+    it("addLink reference", () => {
+        let link0 = {
+            $ref: "#/components/links/id"
         };
         let sut = OpenApiBuilder.create().addLink("link0", link0).rootDoc;
         expect(sut.components.links.link0).eql(link0);
@@ -253,6 +309,13 @@ describe("OpenApiBuilder", () => {
                     }
                 }
             }
+        };
+        let sut = OpenApiBuilder.create().addCallback("cb1", cb1).rootDoc;
+        expect(sut.components.callbacks.cb1).eql(cb1);
+    });
+    it("addCallback reference", () => {
+        let cb1 = {
+            $ref: "#/components/callbacks/id"
         };
         let sut = OpenApiBuilder.create().addCallback("cb1", cb1).rootDoc;
         expect(sut.components.callbacks.cb1).eql(cb1);

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -96,39 +96,39 @@ export class OpenApiBuilder {
         this.rootDoc.paths[path] = pathItem;
         return this;
     }
-    addSchema(name: string, schema: oa.SchemaObject): OpenApiBuilder {
+    addSchema(name: string, schema: oa.SchemaObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.schemas[name] = schema;
         return this;
     }
-    addResponse(name: string, response: oa.ResponseObject): OpenApiBuilder {
+    addResponse(name: string, response: oa.ResponseObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.responses[name] = response;
         return this;
     }
-    addParameter(name: string, parameter: oa.ParameterObject): OpenApiBuilder {
+    addParameter(name: string, parameter: oa.ParameterObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.parameters[name] = parameter;
         return this;
     }
-    addExample(name: string, example: oa.ExampleObject): OpenApiBuilder {
+    addExample(name: string, example: oa.ExampleObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.examples[name] = example;
         return this;
     }
-    addRequestBody(name: string, reqBody: oa.RequestBodyObject): OpenApiBuilder {
+    addRequestBody(name: string, reqBody: oa.RequestBodyObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.requestBodies[name] = reqBody;
         return this;
     }
-    addHeader(name: string, header: oa.HeaderObject): OpenApiBuilder {
+    addHeader(name: string, header: oa.HeaderObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.headers[name] = header;
         return this;
     }
-    addSecurityScheme(name: string, secScheme: oa.SecuritySchemeObject): OpenApiBuilder {
+    addSecurityScheme(name: string, secScheme: oa.SecuritySchemeObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.securitySchemes[name] = secScheme;
         return this;
     }
-    addLink(name: string, link: oa.LinkObject): OpenApiBuilder {
+    addLink(name: string, link: oa.LinkObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.links[name] = link;
         return this;
     }
-    addCallback(name: string, callback: oa.CallbackObject): OpenApiBuilder {
+    addCallback(name: string, callback: oa.CallbackObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.callbacks[name] = callback;
         return this;
     }

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -53,15 +53,15 @@ export interface ServerVariableObject extends ISpecificationExtension {
     description?: string;
 }
 export interface ComponentsObject extends ISpecificationExtension {
-    schemas?: { [schema: string]: SchemaObject };
-    responses?: { [response: string]: ResponseObject };
-    parameters?: { [parameter: string]: ParameterObject };
-    examples?: { [example: string]: ExampleObject };
-    requestBodies?: { [request: string]: RequestBodyObject };
-    headers?: { [heaer: string]: HeaderObject };
-    securitySchemes?: { [securityScheme: string]: SecuritySchemeObject };
-    links?: { [link: string]: LinkObject };
-    callbacks?: { [callback: string]: CallbackObject };
+    schemas?: { [schema: string]: SchemaObject | ReferenceObject };
+    responses?: { [response: string]: ResponseObject | ReferenceObject };
+    parameters?: { [parameter: string]: ParameterObject | ReferenceObject };
+    examples?: { [example: string]: ExampleObject | ReferenceObject };
+    requestBodies?: { [request: string]: RequestBodyObject | ReferenceObject };
+    headers?: { [heaer: string]: HeaderObject | ReferenceObject };
+    securitySchemes?: { [securityScheme: string]: SecuritySchemeObject | ReferenceObject };
+    links?: { [link: string]: LinkObject | ReferenceObject };
+    callbacks?: { [callback: string]: CallbackObject | ReferenceObject };
 }
 
 /**


### PR DESCRIPTION
Hello 👋 

Raising a PR to sync the type definitions with the spec wrt the presence of references in components, as per https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#componentsObject

Let me know if something is missing, etc etc.

Cheers!

-- Mauri