### PR TITLE
update media type example and examples to match spec v3.0.1

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -228,9 +228,11 @@ describe("OpenApiBuilder", () => {
                     "schema": {
                         "$ref": "#/components/schemas/User"
                     },
-                    "examples": [{
-                        "$ref": "http://foo.bar/examples/user-example.json"
-                    }]
+                    "examples": {
+                        user: {
+                            "$ref": "http://foo.bar/examples/user-example.json"
+                        }
+                    }
                 }
             },
             required: false

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -173,8 +173,8 @@ export interface ContentObject {
 }
 export interface MediaTypeObject extends ISpecificationExtension {
     schema?: SchemaObject | ReferenceObject;
-    examples?: [ ExampleObject | ReferenceObject ];
-    example?: ExampleObject | ReferenceObject;
+    examples?: ExamplesObject;
+    example?: any;
     encoding?: EncodingObject;
 }
 export interface EncodingObject extends ISpecificationExtension {
@@ -243,7 +243,7 @@ export interface TagObject extends ISpecificationExtension {
     [extension: string]: any; // Hack for allowing ISpecificationExtension
 }
 export interface ExamplesObject {
-    [name: string]: any;
+    [name: string]: ExampleObject | ReferenceObject;
 }
 export interface ReferenceObject {
     $ref: string;


### PR DESCRIPTION
Between OAS 3.0.0-rc0 and 3.0.1, the Media Type Object was changed:
* example changed from an Example Object to Any
* examples changed from an array of Example Objects or Reference Objects
  to a map

see Media Type Object for [3.0.0-rc0](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc0/versions/3.0.md#mediaTypeObject) and for [3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#mediaTypeObject).