### PR TITLE
Fix ContactObject interface

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -34,9 +34,9 @@ export interface InfoObject extends ISpecificationExtension {
     version: string;
 }
 export interface ContactObject extends ISpecificationExtension {
-    name: string;
-    url: string;
-    email: string;
+    name?: string;
+    url?: string;
+    email?: string;
 }
 export interface LicenseObject extends ISpecificationExtension {
     name: string;


### PR DESCRIPTION
According to OpenAPI spec, every field of Contact Object is not marked as REQUIRED, but all fields are required in OpenApi.ts.
This PR makes them optional.

Please see the table of Contact Object fields at https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#contactObject