### PR TITLE
Add type guards for SchemaObject and ReferenceObject

### DIFF
--- a/src/model/OpenApi.spec.ts
+++ b/src/model/OpenApi.spec.ts
@@ -1,0 +1,37 @@
+import "mocha";
+import { expect } from "chai";
+import { isSchemaObject, isReferenceObject, SchemaObject, ReferenceObject } from "./OpenApi";
+
+describe('type-guards unit tests', () => {
+    describe('isSchemaObject()', () => {
+        it('returns true for a schema object', () => {
+            const schemaObject = new TestSchemaObject();
+            expect(isSchemaObject(schemaObject)).to.equal(true);
+        });
+
+        it('returns false for a reference object', () => {
+            const referenceObject = new TestReferenceObject();
+            expect(isSchemaObject(referenceObject)).to.equal(false);
+        });
+    });
+
+    describe('isReferenceObject()', () => {
+        it('returns true for a reference object', () => {
+            const referenceObject = new TestReferenceObject();
+            expect(isReferenceObject(referenceObject)).to.equal(true);
+        });
+
+        it('returns false for a schema object', () => {
+            const schemaObject = new TestSchemaObject();
+            expect(isReferenceObject(schemaObject)).to.equal(false);
+        });
+    });
+});
+
+class TestSchemaObject implements SchemaObject {
+    // empty schema
+}
+
+class TestReferenceObject implements ReferenceObject {
+    $ref = 'test';
+}

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -245,9 +245,21 @@ export interface TagObject extends ISpecificationExtension {
 export interface ExamplesObject {
     [name: string]: ExampleObject | ReferenceObject;
 }
+
 export interface ReferenceObject {
     $ref: string;
 }
+
+/**
+ * A type guard to check if the given value is a `ReferenceObject`.
+ * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
+ *
+ * @param obj The value to check.
+ */
+export function isReferenceObject(obj: object): obj is ReferenceObject {
+    return obj.hasOwnProperty("$ref");
+}
+
 export interface SchemaObject extends ISpecificationExtension {
     nullable?: boolean;
     discriminator?: DiscriminatorObject;
@@ -287,6 +299,19 @@ export interface SchemaObject extends ISpecificationExtension {
     minProperties?: number;
     required?: string[];
     enum?: any[];
+}
+
+/**
+ * A type guard to check if the given object is a `SchemaObject`.
+ * Useful to distinguish from `ReferenceObject` values that can be used
+ * in most places where `SchemaObject` is allowed.
+ *
+ * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
+ *
+ * @param schema The value to check.
+ */
+export function isSchemaObject(schema: SchemaObject | ReferenceObject): schema is SchemaObject {
+    return !schema.hasOwnProperty('$ref');
 }
 
 export interface SchemasObject {


### PR DESCRIPTION
Hello from the LoopBack team 👋  We are happily using openapi3-ts in our project (https://github.com/strongloop/loopback-next), although we had to add few more features ourselves. 

In this pull request, I'd like to contribute type guards (see [TypeScript docs](https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types)) we are using to differentiate between `SchemaObject` and `ReferenceObject` types.

@pjmolina please review