### PR TITLE
fix: type is mandatory

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -271,7 +271,7 @@ export interface SchemaObject extends ISpecificationExtension {
     examples?: any[];
     deprecated?: boolean;
 
-    type?: string;
+    type: string;
     allOf?: (SchemaObject | ReferenceObject)[];
     oneOf?: (SchemaObject | ReferenceObject)[];
     anyOf?: (SchemaObject | ReferenceObject)[];


### PR DESCRIPTION
According to the OpenAPI 3.0 specification, `type` Value MUST be a string. Multiple types via an array are not supported.