### PR TITLE
more precise schema type definitions

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -271,7 +271,8 @@ export interface SchemaObject extends ISpecificationExtension {
     examples?: any[];
     deprecated?: boolean;
 
-    type?: string;
+    type?: 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array';
+    format?: 'int32' | 'int64' | 'float' | 'double' | 'byte' | 'binary' | 'date' | 'date-time' | 'password';
     allOf?: (SchemaObject | ReferenceObject)[];
     oneOf?: (SchemaObject | ReferenceObject)[];
     anyOf?: (SchemaObject | ReferenceObject)[];
@@ -280,7 +281,6 @@ export interface SchemaObject extends ISpecificationExtension {
     properties?: {[propertyName: string]: (SchemaObject | ReferenceObject)};
     additionalProperties?: (SchemaObject | ReferenceObject | boolean);
     description?: string;
-    format?: string;
     default?: any;
 
     title?: string;


### PR DESCRIPTION
More precise type definitions to Schema interface's `format` and `type` properties.

As defined in [OpenAPI Specification - Data Types](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#data-types) and possible range of values for JSON instance types [here](https://tools.ietf.org/html/draft-wright-json-schema-00#section-4.2), I made mentioned [Schema interface](https://github.com/metadevpro/openapi3-ts/blob/master/src/model/OpenApi.ts#L263) properties more precise which also increases developer experience with editor type hinting, as shown in the following two images:
![image](https://user-images.githubusercontent.com/29199390/93558344-7d3e5580-f992-11ea-8890-9e8a5c44ddba.png)
![image](https://user-images.githubusercontent.com/29199390/93558387-947d4300-f992-11ea-96e2-e52158f2fcf1.png)
