### PR TITLE
Add missing void type

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -271,7 +271,7 @@ export interface SchemaObject extends ISpecificationExtension {
     examples?: any[];
     deprecated?: boolean;
 
-    type?: 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array';
+    type?: 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array' | 'void';
     format?: 'int32' | 'int64' | 'float' | 'double' | 'byte' | 'binary' | 'date' | 'date-time' | 'password' | string;
     allOf?: (SchemaObject | ReferenceObject)[];
     oneOf?: (SchemaObject | ReferenceObject)[];


### PR DESCRIPTION
Looks like https://github.com/metadevpro/openapi3-ts/pull/65 forgot the `void` type.