### PR TITLE
Making exclusive parameter numbers

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -301,9 +301,9 @@ export interface SchemaObject extends ISpecificationExtension {
     title?: string;
     multipleOf?: number;
     maximum?: number;
-    exclusiveMaximum?: boolean;
+    exclusiveMaximum?: number;
     minimum?: number;
-    exclusiveMinimum?: boolean;
+    exclusiveMinimum?: number;
     maxLength?: number;
     minLength?: number;
     pattern?: string;


### PR DESCRIPTION
As the OpenAPI/JSON Schema specification defines, exclusiveMinimum & exclusiveMaximum should be boolean variables
___
Fixing issue #78 