### PR TITLE
Emit helpers to the CJS build.

### DIFF
--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "target": "ES2015",
         "module": "commonjs",
-        "outDir": "dist/cjs"
+        "outDir": "dist/cjs",
+        "noEmitHelpers": false
     }
 }


### PR DESCRIPTION
Fixes the issue #81 by restoring the default value of `noEmitHelpers` in the CJS build configuration.
