### PR TITLE
Backward compatibility to OpenAPI v3.0

### DIFF
--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -4,16 +4,18 @@ import * as oa from '../model/index.js';
 // Internal DSL for building an OpenAPI 3.0.x contract
 // using a fluent interface
 
-export class OpenApiBuilder {
-    rootDoc: oa.OpenAPIObject;
+const defaultOpenAPIVersion: oa.OpenAPIVersion = '3.0.0';
 
-    static create(doc?: oa.OpenAPIObject): OpenApiBuilder {
+export class OpenApiBuilder<V extends oa.OpenAPIVersion = typeof defaultOpenAPIVersion> {
+    rootDoc: oa.OpenAPIObject<V>;
+
+    static create<T extends oa.OpenAPIVersion>(doc?: oa.OpenAPIObject<T>): OpenApiBuilder<T> {
         return new OpenApiBuilder(doc);
     }
 
-    constructor(doc?: oa.OpenAPIObject) {
+    constructor(doc?: oa.OpenAPIObject<V>) {
         this.rootDoc = doc || {
-            openapi: '3.0.0',
+            openapi: defaultOpenAPIVersion as V,
             info: {
                 title: 'app',
                 version: 'version'
@@ -35,7 +37,7 @@ export class OpenApiBuilder {
         };
     }
 
-    getSpec(): oa.OpenAPIObject {
+    getSpec(): oa.OpenAPIObject<V> {
         return this.rootDoc;
     }
 
@@ -61,7 +63,7 @@ export class OpenApiBuilder {
         return false;
     }
 
-    addOpenApiVersion(openApiVersion: string): OpenApiBuilder {
+    addOpenApiVersion(openApiVersion: V): OpenApiBuilder<V> {
         if (!OpenApiBuilder.isValidOpenApiVersion(openApiVersion)) {
             throw new Error(
                 'Invalid OpenApi version: ' + openApiVersion + '. Follow convention: 3.x.y'
@@ -70,89 +72,98 @@ export class OpenApiBuilder {
         this.rootDoc.openapi = openApiVersion;
         return this;
     }
-    addInfo(info: oa.InfoObject): OpenApiBuilder {
+    addInfo(info: oa.InfoObject): OpenApiBuilder<V> {
         this.rootDoc.info = info;
         return this;
     }
-    addContact(contact: oa.ContactObject): OpenApiBuilder {
+    addContact(contact: oa.ContactObject): OpenApiBuilder<V> {
         this.rootDoc.info.contact = contact;
         return this;
     }
-    addLicense(license: oa.LicenseObject): OpenApiBuilder {
+    addLicense(license: oa.LicenseObject): OpenApiBuilder<V> {
         this.rootDoc.info.license = license;
         return this;
     }
-    addTitle(title: string): OpenApiBuilder {
+    addTitle(title: string): OpenApiBuilder<V> {
         this.rootDoc.info.title = title;
         return this;
     }
-    addDescription(description: string): OpenApiBuilder {
+    addDescription(description: string): OpenApiBuilder<V> {
         this.rootDoc.info.description = description;
         return this;
     }
-    addTermsOfService(termsOfService: string): OpenApiBuilder {
+    addTermsOfService(termsOfService: string): OpenApiBuilder<V> {
         this.rootDoc.info.termsOfService = termsOfService;
         return this;
     }
-    addVersion(version: string): OpenApiBuilder {
+    addVersion(version: string): OpenApiBuilder<V> {
         this.rootDoc.info.version = version;
         return this;
     }
-    addPath(path: string, pathItem: oa.PathItemObject): OpenApiBuilder {
+    addPath(path: string, pathItem: oa.PathItemObject<V>): OpenApiBuilder<V> {
         this.rootDoc.paths[path] = pathItem;
         return this;
     }
-    addSchema(name: string, schema: oa.SchemaObject | oa.ReferenceObject): OpenApiBuilder {
+    addSchema(name: string, schema: oa.SchemaObject<V> | oa.ReferenceObject): OpenApiBuilder<V> {
         this.rootDoc.components.schemas[name] = schema;
         return this;
     }
-    addResponse(name: string, response: oa.ResponseObject | oa.ReferenceObject): OpenApiBuilder {
+    addResponse(
+        name: string,
+        response: oa.ResponseObject<V> | oa.ReferenceObject
+    ): OpenApiBuilder<V> {
         this.rootDoc.components.responses[name] = response;
         return this;
     }
-    addParameter(name: string, parameter: oa.ParameterObject | oa.ReferenceObject): OpenApiBuilder {
+    addParameter(
+        name: string,
+        parameter: oa.ParameterObject<V> | oa.ReferenceObject
+    ): OpenApiBuilder<V> {
         this.rootDoc.components.parameters[name] = parameter;
         return this;
     }
-    addExample(name: string, example: oa.ExampleObject | oa.ReferenceObject): OpenApiBuilder {
+    addExample(name: string, example: oa.ExampleObject | oa.ReferenceObject): OpenApiBuilder<V> {
         this.rootDoc.components.examples[name] = example;
         return this;
     }
     addRequestBody(
         name: string,
-        reqBody: oa.RequestBodyObject | oa.ReferenceObject
-    ): OpenApiBuilder {
+        reqBody: oa.RequestBodyObject<V> | oa.ReferenceObject
+    ): OpenApiBuilder<V> {
         this.rootDoc.components.requestBodies[name] = reqBody;
         return this;
     }
-    addHeader(name: string, header: oa.HeaderObject | oa.ReferenceObject): OpenApiBuilder {
+    addHeader(name: string, header: oa.HeaderObject<V> | oa.ReferenceObject): OpenApiBuilder<V> {
         this.rootDoc.components.headers[name] = header;
         return this;
     }
     addSecurityScheme(
         name: string,
         secScheme: oa.SecuritySchemeObject | oa.ReferenceObject
-    ): OpenApiBuilder {
+    ): OpenApiBuilder<V> {
         this.rootDoc.components.securitySchemes[name] = secScheme;
         return this;
     }
-    addLink(name: string, link: oa.LinkObject | oa.ReferenceObject): OpenApiBuilder {
+    addLink(name: string, link: oa.LinkObject | oa.ReferenceObject): OpenApiBuilder<V> {
         this.rootDoc.components.links[name] = link;
         return this;
     }
-    addCallback(name: string, callback: oa.CallbackObject | oa.ReferenceObject): OpenApiBuilder {
+    addCallback(
+        name: string,
+        callback: oa.CallbackObject<V> | oa.ReferenceObject
+    ): OpenApiBuilder<V> {
         this.rootDoc.components.callbacks[name] = callback;
         return this;
     }
-    addServer(server: oa.ServerObject): OpenApiBuilder {
+    addServer(server: oa.ServerObject): OpenApiBuilder<V> {
         this.rootDoc.servers.push(server);
         return this;
     }
-    addTag(tag: oa.TagObject): OpenApiBuilder {
+    addTag(tag: oa.TagObject): OpenApiBuilder<V> {
         this.rootDoc.tags.push(tag);
         return this;
     }
-    addExternalDocs(extDoc: oa.ExternalDocumentationObject): OpenApiBuilder {
+    addExternalDocs(extDoc: oa.ExternalDocumentationObject): OpenApiBuilder<V> {
         this.rootDoc.externalDocs = extDoc;
         return this;
     }

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -1,7 +1,7 @@
 import * as yaml from 'yaml';
 import * as oa from '../model/index.js';
 
-// Internal DSL for building an OpenAPI 3.0.x contract
+// Internal DSL for building an OpenAPI 3.0.x (default) or 3.1.x contract
 // using a fluent interface
 
 const defaultOpenAPIVersion: oa.OpenAPIVersion = '3.0.0';

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -304,8 +304,10 @@ export interface SchemaObject<V extends OpenAPIVersion> extends ISpecificationEx
     title?: string;
     multipleOf?: number;
     maximum?: number;
+    /** @desc a number in OpenAPI 3.1.x and a boolean in 3.0.x */
     exclusiveMaximum?: V extends `3.1.${number}` ? number : boolean;
     minimum?: number;
+    /** @desc a number in OpenAPI 3.1.x and a boolean in 3.0.x */
     exclusiveMinimum?: V extends `3.1.${number}` ? number : boolean;
     maxLength?: number;
     minLength?: number;

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// Typed interfaces for OpenAPI 3.0.0-RC
-// see https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc0/versions/3.0.md
+// Typed interfaces for OpenAPI 3.0.0 and 3.1.0
+// see https://github.com/OAI/OpenAPI-Specification/tree/main/versions
 
 import { ISpecificationExtension, SpecificationExtension } from './SpecificationExtension.js';
 
@@ -71,10 +71,6 @@ export interface ComponentsObject<V extends OpenAPIVersion> extends ISpecificati
     callbacks?: { [callback: string]: CallbackObject<V> | ReferenceObject };
 }
 
-/**
- * Rename it to Paths Object to be consistent with the spec
- * See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathsObject
- */
 export interface PathsObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     // [path: string]: PathItemObject;
     [path: string]: PathItemObject<V> | any; // Hack for allowing ISpecificationExtension
@@ -84,7 +80,7 @@ export interface PathsObject<V extends OpenAPIVersion> extends ISpecificationExt
  * @deprecated
  * Create a type alias for backward compatibility
  */
-export type PathObject = PathsObject<OpenAPIVersion>;
+export type PathObject<V extends OpenAPIVersion> = PathsObject<V>;
 
 export function getPath<V extends OpenAPIVersion = OpenAPIVersion>(
     pathsObject: PathsObject<V>,

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -20,12 +20,14 @@ export function addExtension(
     }
 }
 
-export interface OpenAPIObject extends ISpecificationExtension {
-    openapi: string;
+export type OpenAPIVersion = `3.0.${number}` | `3.1.${number}`;
+
+export interface OpenAPIObject<V extends OpenAPIVersion> extends ISpecificationExtension {
+    openapi: V;
     info: InfoObject;
     servers?: ServerObject[];
-    paths: PathsObject;
-    components?: ComponentsObject;
+    paths: PathsObject<V>;
+    components?: ComponentsObject<V>;
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
@@ -57,65 +59,68 @@ export interface ServerVariableObject extends ISpecificationExtension {
     default: string | boolean | number;
     description?: string;
 }
-export interface ComponentsObject extends ISpecificationExtension {
-    schemas?: { [schema: string]: SchemaObject | ReferenceObject };
-    responses?: { [response: string]: ResponseObject | ReferenceObject };
-    parameters?: { [parameter: string]: ParameterObject | ReferenceObject };
+export interface ComponentsObject<V extends OpenAPIVersion> extends ISpecificationExtension {
+    schemas?: { [schema: string]: SchemaObject<V> | ReferenceObject };
+    responses?: { [response: string]: ResponseObject<V> | ReferenceObject };
+    parameters?: { [parameter: string]: ParameterObject<V> | ReferenceObject };
     examples?: { [example: string]: ExampleObject | ReferenceObject };
-    requestBodies?: { [request: string]: RequestBodyObject | ReferenceObject };
-    headers?: { [header: string]: HeaderObject | ReferenceObject };
+    requestBodies?: { [request: string]: RequestBodyObject<V> | ReferenceObject };
+    headers?: { [header: string]: HeaderObject<V> | ReferenceObject };
     securitySchemes?: { [securityScheme: string]: SecuritySchemeObject | ReferenceObject };
     links?: { [link: string]: LinkObject | ReferenceObject };
-    callbacks?: { [callback: string]: CallbackObject | ReferenceObject };
+    callbacks?: { [callback: string]: CallbackObject<V> | ReferenceObject };
 }
 
 /**
  * Rename it to Paths Object to be consistent with the spec
  * See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathsObject
  */
-export interface PathsObject extends ISpecificationExtension {
+export interface PathsObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     // [path: string]: PathItemObject;
-    [path: string]: PathItemObject | any; // Hack for allowing ISpecificationExtension
+    [path: string]: PathItemObject<V> | any; // Hack for allowing ISpecificationExtension
 }
 
 /**
  * @deprecated
  * Create a type alias for backward compatibility
  */
-export type PathObject = PathsObject;
+export type PathObject = PathsObject<OpenAPIVersion>;
 
-export function getPath(pathsObject: PathsObject, path: string): PathItemObject | undefined {
+export function getPath<V extends OpenAPIVersion = OpenAPIVersion>(
+    pathsObject: PathsObject<V>,
+    path: string
+): PathItemObject<V> | undefined {
     if (SpecificationExtension.isValidExtension(path)) {
         return undefined;
     }
-    return pathsObject[path] as PathItemObject;
+    return pathsObject[path] as PathItemObject<V>;
 }
 
-export interface PathItemObject extends ISpecificationExtension {
+export interface PathItemObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     $ref?: string;
     summary?: string;
     description?: string;
-    get?: OperationObject;
-    put?: OperationObject;
-    post?: OperationObject;
-    delete?: OperationObject;
-    options?: OperationObject;
-    head?: OperationObject;
-    patch?: OperationObject;
-    trace?: OperationObject;
+    get?: OperationObject<V>;
+    put?: OperationObject<V>;
+    post?: OperationObject<V>;
+    delete?: OperationObject<V>;
+    options?: OperationObject<V>;
+    head?: OperationObject<V>;
+    patch?: OperationObject<V>;
+    trace?: OperationObject<V>;
     servers?: ServerObject[];
-    parameters?: (ParameterObject | ReferenceObject)[];
+    parameters?: (ParameterObject<V> | ReferenceObject)[];
 }
-export interface OperationObject extends ISpecificationExtension {
+export interface OperationObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     tags?: string[];
     summary?: string;
     description?: string;
     externalDocs?: ExternalDocumentationObject;
     operationId?: string;
-    parameters?: (ParameterObject | ReferenceObject)[];
-    requestBody?: RequestBodyObject | ReferenceObject;
-    responses: ResponsesObject;
-    callbacks?: CallbacksObject;
+    parameters?: (ParameterObject<V> | ReferenceObject)[];
+    requestBody?: RequestBodyObject<V> | ReferenceObject;
+    responses: ResponsesObject<V>;
+    callbacks?: CallbacksObject<V>;
     deprecated?: boolean;
     security?: SecurityRequirementObject[];
     servers?: ServerObject[];
@@ -149,7 +154,7 @@ export type ParameterStyle =
     | 'pipeDelimited'
     | 'deepObject';
 
-export interface BaseParameterObject extends ISpecificationExtension {
+export interface BaseParameterObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     description?: string;
     required?: boolean;
     deprecated?: boolean;
@@ -158,64 +163,64 @@ export interface BaseParameterObject extends ISpecificationExtension {
     style?: ParameterStyle; // "matrix" | "label" | "form" | "simple" | "spaceDelimited" | "pipeDelimited" | "deepObject";
     explode?: boolean;
     allowReserved?: boolean;
-    schema?: SchemaObject | ReferenceObject;
+    schema?: SchemaObject<V> | ReferenceObject;
     examples?: { [param: string]: ExampleObject | ReferenceObject };
     example?: any;
-    content?: ContentObject;
+    content?: ContentObject<V>;
 }
 
-export interface ParameterObject extends BaseParameterObject {
+export interface ParameterObject<V extends OpenAPIVersion> extends BaseParameterObject<V> {
     name: string;
     in: ParameterLocation; // "query" | "header" | "path" | "cookie";
 }
-export interface RequestBodyObject extends ISpecificationExtension {
+export interface RequestBodyObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     description?: string;
-    content: ContentObject;
+    content: ContentObject<V>;
     required?: boolean;
 }
-export interface ContentObject {
-    [mediatype: string]: MediaTypeObject;
+export interface ContentObject<V extends OpenAPIVersion> {
+    [mediatype: string]: MediaTypeObject<V>;
 }
-export interface MediaTypeObject extends ISpecificationExtension {
-    schema?: SchemaObject | ReferenceObject;
+export interface MediaTypeObject<V extends OpenAPIVersion> extends ISpecificationExtension {
+    schema?: SchemaObject<V> | ReferenceObject;
     examples?: ExamplesObject;
     example?: any;
-    encoding?: EncodingObject;
+    encoding?: EncodingObject<V>;
 }
-export interface EncodingObject extends ISpecificationExtension {
+export interface EncodingObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     // [property: string]: EncodingPropertyObject;
-    [property: string]: EncodingPropertyObject | any; // Hack for allowing ISpecificationExtension
+    [property: string]: EncodingPropertyObject<V> | any; // Hack for allowing ISpecificationExtension
 }
-export interface EncodingPropertyObject {
+export interface EncodingPropertyObject<V extends OpenAPIVersion> {
     contentType?: string;
-    headers?: { [key: string]: HeaderObject | ReferenceObject };
+    headers?: { [key: string]: HeaderObject<V> | ReferenceObject };
     style?: string;
     explode?: boolean;
     allowReserved?: boolean;
     [key: string]: any; // (any) = Hack for allowing ISpecificationExtension
 }
-export interface ResponsesObject extends ISpecificationExtension {
-    default?: ResponseObject | ReferenceObject;
+export interface ResponsesObject<V extends OpenAPIVersion> extends ISpecificationExtension {
+    default?: ResponseObject<V> | ReferenceObject;
 
     // [statuscode: string]: ResponseObject | ReferenceObject;
-    [statuscode: string]: ResponseObject | ReferenceObject | any; // (any) = Hack for allowing ISpecificationExtension
+    [statuscode: string]: ResponseObject<V> | ReferenceObject | any; // (any) = Hack for allowing ISpecificationExtension
 }
-export interface ResponseObject extends ISpecificationExtension {
+export interface ResponseObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     description: string;
-    headers?: HeadersObject;
-    content?: ContentObject;
+    headers?: HeadersObject<V>;
+    content?: ContentObject<V>;
     links?: LinksObject;
 }
-export interface CallbacksObject extends ISpecificationExtension {
+export interface CallbacksObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     // [name: string]: CallbackObject | ReferenceObject;
-    [name: string]: CallbackObject | ReferenceObject | any; // Hack for allowing ISpecificationExtension
+    [name: string]: CallbackObject<V> | ReferenceObject | any; // Hack for allowing ISpecificationExtension
 }
-export interface CallbackObject extends ISpecificationExtension {
+export interface CallbackObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     // [name: string]: PathItemObject;
-    [name: string]: PathItemObject | any; // Hack for allowing ISpecificationExtension
+    [name: string]: PathItemObject<V> | any; // Hack for allowing ISpecificationExtension
 }
-export interface HeadersObject {
-    [name: string]: HeaderObject | ReferenceObject;
+export interface HeadersObject<V extends OpenAPIVersion> {
+    [name: string]: HeaderObject<V> | ReferenceObject;
 }
 export interface ExampleObject {
     summary?: string;
@@ -240,7 +245,7 @@ export interface LinkParametersObject {
     [name: string]: any | string;
 }
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface HeaderObject extends BaseParameterObject {
+export interface HeaderObject<V extends OpenAPIVersion> extends BaseParameterObject<V> {
     $ref?: string;
 }
 export interface TagObject extends ISpecificationExtension {
@@ -267,7 +272,7 @@ export function isReferenceObject(obj: any): obj is ReferenceObject {
     return Object.prototype.hasOwnProperty.call(obj, '$ref');
 }
 
-export interface SchemaObject extends ISpecificationExtension {
+export interface SchemaObject<V extends OpenAPIVersion> extends ISpecificationExtension {
     nullable?: boolean;
     discriminator?: DiscriminatorObject;
     readOnly?: boolean;
@@ -290,22 +295,22 @@ export interface SchemaObject extends ISpecificationExtension {
         | 'date-time'
         | 'password'
         | string;
-    allOf?: (SchemaObject | ReferenceObject)[];
-    oneOf?: (SchemaObject | ReferenceObject)[];
-    anyOf?: (SchemaObject | ReferenceObject)[];
-    not?: SchemaObject | ReferenceObject;
-    items?: SchemaObject | ReferenceObject;
-    properties?: { [propertyName: string]: SchemaObject | ReferenceObject };
-    additionalProperties?: SchemaObject | ReferenceObject | boolean;
+    allOf?: (SchemaObject<V> | ReferenceObject)[];
+    oneOf?: (SchemaObject<V> | ReferenceObject)[];
+    anyOf?: (SchemaObject<V> | ReferenceObject)[];
+    not?: SchemaObject<V> | ReferenceObject;
+    items?: SchemaObject<V> | ReferenceObject;
+    properties?: { [propertyName: string]: SchemaObject<V> | ReferenceObject };
+    additionalProperties?: SchemaObject<V> | ReferenceObject | boolean;
     description?: string;
     default?: any;
 
     title?: string;
     multipleOf?: number;
     maximum?: number;
-    exclusiveMaximum?: number;
+    exclusiveMaximum?: V extends `3.1.${number}` ? number : boolean;
     minimum?: number;
-    exclusiveMinimum?: number;
+    exclusiveMinimum?: V extends `3.1.${number}` ? number : boolean;
     maxLength?: number;
     minLength?: number;
     pattern?: string;
@@ -327,12 +332,14 @@ export interface SchemaObject extends ISpecificationExtension {
  *
  * @param schema The value to check.
  */
-export function isSchemaObject(schema: SchemaObject | ReferenceObject): schema is SchemaObject {
+export function isSchemaObject<V extends OpenAPIVersion = OpenAPIVersion>(
+    schema: SchemaObject<V> | ReferenceObject
+): schema is SchemaObject<V> {
     return !Object.prototype.hasOwnProperty.call(schema, '$ref');
 }
 
-export interface SchemasObject {
-    [schema: string]: SchemaObject;
+export interface SchemasObject<V extends OpenAPIVersion> {
+    [schema: string]: SchemaObject<V>;
 }
 
 export interface DiscriminatorObject {

--- a/src/model/SpecificationExtension.ts
+++ b/src/model/SpecificationExtension.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-// Suport for Specification Extensions
+// Support for Specification Extensions
 // as described in
 // https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc0/versions/3.0.md#specificationExtensions
 


### PR DESCRIPTION
This PR might fix the issue #83 by making several types and the builder class generic.
The generic types depend on the new type `OpenAPIVersion` that differentiates `3.0.x` and `3.1.x`.

Some properties like `exclusiveMinimum` and `exclusiveMaximum` become either boolean (3.0.x) or number (3.1.x) depending on the OpenAPI version.

Since the default OpenAPI version is `3.0.0` (though it can be determined automatically from the `openapi` parameter), these changes might be considered as breaking to the current major version of the library.

I'm open to any suggestions and recommendations on how I could improve this PR to support both 3.0 and 3.1.

Closes #83 