### PR TITLE
Support both number and boolean for exclusive numbers.

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -303,9 +303,11 @@ export interface SchemaObject extends ISpecificationExtension {
     title?: string;
     multipleOf?: number;
     maximum?: number;
-    exclusiveMaximum?: number;
+    /** @desc OpenAPI 3.0: boolean, OpenAPI 3.1: number */
+    exclusiveMaximum?: number | boolean;
     minimum?: number;
-    exclusiveMinimum?: number;
+    /** @desc OpenAPI 3.0: boolean, OpenAPI 3.1: number */
+    exclusiveMinimum?: number | boolean;
     maxLength?: number;
     minLength?: number;
     pattern?: string;


### PR DESCRIPTION
Closes #83 

In accordance with https://github.com/metadevpro/openapi3-ts/pull/84#issuecomment-1228367548.

Supporting both `number` and `boolean` for `exclusiveMaximum` and `exclusiveMinimum`.
