### PR TITLE
fix: change yaml to optional function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
             "name": "openapi3-ts",
             "version": "3.0.2",
             "license": "MIT",
-            "dependencies": {
-                "yaml": "^2.1.1"
-            },
             "devDependencies": {
                 "@types/node": "^18.7.13",
                 "@typescript-eslint/eslint-plugin": "^5.35.1",
@@ -24,7 +21,8 @@
                 "rimraf": "^3.0.2",
                 "typescript": "~4.7.4",
                 "vitest": "^0.22.1",
-                "vitest-teamcity-reporter": "^0.1.7"
+                "vitest-teamcity-reporter": "^0.1.7",
+                "yaml": "^2.1.1"
             }
         },
         "node_modules/@bcoe/v8-coverage": {
@@ -2734,6 +2732,7 @@
         },
         "node_modules/yaml": {
             "version": "2.1.1",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">= 14"
@@ -4424,7 +4423,8 @@
             "dev": true
         },
         "yaml": {
-            "version": "2.1.1"
+            "version": "2.1.1",
+            "dev": true
         },
         "yargs": {
             "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     ],
     "author": "Pedro J. Molina / Metadev",
     "license": "MIT",
-    "dependencies": {
-        "yaml": "^2.1.1"
-    },
+    "dependencies": {},
     "devDependencies": {
         "@types/node": "^18.7.13",
         "@typescript-eslint/eslint-plugin": "^5.35.1",
@@ -45,6 +43,7 @@
         "rimraf": "^3.0.2",
         "typescript": "~4.7.4",
         "vitest": "^0.22.1",
-        "vitest-teamcity-reporter": "^0.1.7"
+        "vitest-teamcity-reporter": "^0.1.7",
+        "yaml": "^2.1.1"
     }
 }

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -1,4 +1,4 @@
-import * as yaml from 'yaml';
+import type * as yaml from 'yaml';
 import * as oa from '../model/index.js';
 
 // Internal DSL for building an OpenAPI 3.0.x contract
@@ -46,7 +46,17 @@ export class OpenApiBuilder {
         return JSON.stringify(this.rootDoc, replacer, space);
     }
     getSpecAsYaml(): string {
-        return yaml.stringify(this.rootDoc);
+        let yml: typeof yaml;
+        try {
+            yml = require('yaml');
+        } catch (err) {
+            if (err.code === 'MODULE_NOT_FOUND') {
+                throw new Error('Please install yaml package first');
+            } else {
+                throw err;
+            }
+        }
+        return yml.stringify(this.rootDoc);
     }
 
     private static isValidOpenApiVersion(v: string): boolean {


### PR DESCRIPTION
`yaml` cannot be used for node v12 and earlier.

Therefore, it is changed to an optional function. Install `yaml` separately to use `getSpecAsYaml`