### PR TITLE
Enable type array for schema object

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -267,6 +267,8 @@ export function isReferenceObject(obj: any): obj is ReferenceObject {
     return Object.prototype.hasOwnProperty.call(obj, '$ref');
 }
 
+type SchemaObjectType = 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array'
+
 export interface SchemaObject extends ISpecificationExtension {
     nullable?: boolean;
     discriminator?: DiscriminatorObject;
@@ -278,7 +280,7 @@ export interface SchemaObject extends ISpecificationExtension {
     examples?: any[];
     deprecated?: boolean;
 
-    type?: 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array';
+    type?: SchemaObjectType | SchemaObjectType[];
     format?:
         | 'int32'
         | 'int64'


### PR DESCRIPTION
Hello! I was trying to use Open API 3.1 and noticed that the types don't currently support type arrays.

https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

![image](https://user-images.githubusercontent.com/18017094/194182553-691ebee6-96ff-4bfd-bbb3-814839f80c06.png)
