### PR TITLE
Add webhooks support

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -22,7 +22,8 @@ describe('OpenApiBuilder', () => {
                 callbacks: {}
             },
             tags: [],
-            servers: []
+            servers: [],
+            webhooks: {}
         });
     });
     it('Build with custom object', () => {
@@ -131,6 +132,20 @@ describe('OpenApiBuilder', () => {
         };
         const sut = OpenApiBuilder.create().addPath('/path1', path1).rootDoc;
         expect(sut.paths['/path1']).eql(path1);
+    });
+
+    it('addWebhook', () => {
+        const webhook1 = {
+            post: {
+                responses: {
+                    default: {
+                        description: 'event processed'
+                    }
+                }
+            }
+        };
+        const sut = OpenApiBuilder.create().addWebhook('webhook1', webhook1).rootDoc;
+        expect(sut.webhooks['webhook1']).eql(webhook1);
     });
     it('addSchema', () => {
         const schema1: oa.SchemaObject = {
@@ -393,7 +408,7 @@ describe('OpenApiBuilder', () => {
                 .addVersion('5.6.7')
                 .getSpecAsJson();
             expect(sut).eql(
-                `{"openapi":"3.0.0","info":{"title":"app9","version":"5.6.7"},"paths":{},"components":{"schemas":{},"responses":{},"parameters":{},"examples":{},"requestBodies":{},"headers":{},"securitySchemes":{},"links":{},"callbacks":{}},"tags":[],"servers":[]}`
+                `{"openapi":"3.0.0","info":{"title":"app9","version":"5.6.7"},"paths":{},"components":{"schemas":{},"responses":{},"parameters":{},"examples":{},"requestBodies":{},"headers":{},"securitySchemes":{},"links":{},"callbacks":{}},"tags":[],"servers":[],"webhooks":{}}`
             );
         });
         it('getSpecAsYaml', () => {
@@ -402,7 +417,7 @@ describe('OpenApiBuilder', () => {
                 .addVersion('5.6.7')
                 .getSpecAsYaml();
             expect(sut).eql(
-                'openapi: 3.0.0\ninfo:\n  title: app9\n  version: 5.6.7\npaths: {}\ncomponents:\n  schemas: {}\n  responses: {}\n  parameters: {}\n  examples: {}\n  requestBodies: {}\n  headers: {}\n  securitySchemes: {}\n  links: {}\n  callbacks: {}\ntags: []\nservers: []\n'
+                'openapi: 3.0.0\ninfo:\n  title: app9\n  version: 5.6.7\npaths: {}\ncomponents:\n  schemas: {}\n  responses: {}\n  parameters: {}\n  examples: {}\n  requestBodies: {}\n  headers: {}\n  securitySchemes: {}\n  links: {}\n  callbacks: {}\ntags: []\nservers: []\nwebhooks: {}\n'
             );
         });
     });

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -31,7 +31,8 @@ export class OpenApiBuilder {
                 callbacks: {}
             },
             tags: [],
-            servers: []
+            servers: [],
+            webhooks: {}
         };
     }
 
@@ -154,6 +155,10 @@ export class OpenApiBuilder {
     }
     addExternalDocs(extDoc: oa.ExternalDocumentationObject): OpenApiBuilder {
         this.rootDoc.externalDocs = extDoc;
+        return this;
+    }
+    addWebhook(webhook: string, webhookItem: oa.PathItemObject): OpenApiBuilder {
+        this.rootDoc.webhooks[webhook] = webhookItem;
         return this;
     }
 }

--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -29,6 +29,7 @@ export interface OpenAPIObject extends ISpecificationExtension {
     security?: SecurityRequirementObject[];
     tags?: TagObject[];
     externalDocs?: ExternalDocumentationObject;
+    webhooks?: PathsObject;
 }
 export interface InfoObject extends ISpecificationExtension {
     title: string;


### PR DESCRIPTION
Adds webhooks support. Webhook can take a path object so we can just reuse the type.

https://github.com/OAI/OpenAPI-Specification/blob/main/examples/v3.1/webhook-example.yaml