### PR TITLE
Make webhooks optional

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -22,8 +22,7 @@ describe('OpenApiBuilder', () => {
                 callbacks: {}
             },
             tags: [],
-            servers: [],
-            webhooks: {}
+            servers: []
         });
     });
     it('Build with custom object', () => {
@@ -408,7 +407,7 @@ describe('OpenApiBuilder', () => {
                 .addVersion('5.6.7')
                 .getSpecAsJson();
             expect(sut).eql(
-                `{"openapi":"3.0.0","info":{"title":"app9","version":"5.6.7"},"paths":{},"components":{"schemas":{},"responses":{},"parameters":{},"examples":{},"requestBodies":{},"headers":{},"securitySchemes":{},"links":{},"callbacks":{}},"tags":[],"servers":[],"webhooks":{}}`
+                `{"openapi":"3.0.0","info":{"title":"app9","version":"5.6.7"},"paths":{},"components":{"schemas":{},"responses":{},"parameters":{},"examples":{},"requestBodies":{},"headers":{},"securitySchemes":{},"links":{},"callbacks":{}},"tags":[],"servers":[]}`
             );
         });
         it('getSpecAsYaml', () => {
@@ -417,7 +416,7 @@ describe('OpenApiBuilder', () => {
                 .addVersion('5.6.7')
                 .getSpecAsYaml();
             expect(sut).eql(
-                'openapi: 3.0.0\ninfo:\n  title: app9\n  version: 5.6.7\npaths: {}\ncomponents:\n  schemas: {}\n  responses: {}\n  parameters: {}\n  examples: {}\n  requestBodies: {}\n  headers: {}\n  securitySchemes: {}\n  links: {}\n  callbacks: {}\ntags: []\nservers: []\nwebhooks: {}\n'
+                'openapi: 3.0.0\ninfo:\n  title: app9\n  version: 5.6.7\npaths: {}\ncomponents:\n  schemas: {}\n  responses: {}\n  parameters: {}\n  examples: {}\n  requestBodies: {}\n  headers: {}\n  securitySchemes: {}\n  links: {}\n  callbacks: {}\ntags: []\nservers: []\n'
             );
         });
     });

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -31,8 +31,7 @@ export class OpenApiBuilder {
                 callbacks: {}
             },
             tags: [],
-            servers: [],
-            webhooks: {}
+            servers: []
         };
     }
 
@@ -158,6 +157,7 @@ export class OpenApiBuilder {
         return this;
     }
     addWebhook(webhook: string, webhookItem: oa.PathItemObject): OpenApiBuilder {
+        this.rootDoc.webhooks ??= {};
         this.rootDoc.webhooks[webhook] = webhookItem;
         return this;
     }


### PR DESCRIPTION
Fixes the issue raised in https://github.com/metadevpro/openapi3-ts/pull/88#discussion_r990420456

Webhooks does not exist in OpenAPI 3.0