### PR TITLE
feat: merge path

### DIFF
--- a/src/dsl/OpenApiBuilder.spec.ts
+++ b/src/dsl/OpenApiBuilder.spec.ts
@@ -129,8 +129,19 @@ describe('OpenApiBuilder', () => {
                 }
             }
         };
-        const sut = OpenApiBuilder.create().addPath('/path1', path1).rootDoc;
-        expect(sut.paths['/path1']).eql(path1);
+        const doc = OpenApiBuilder.create().addPath('/path1', path1);
+        expect(doc.rootDoc.paths['/path1']).eql(path1);
+        const path2 = {
+            post: {
+                responses: {
+                    default: {
+                        description: 'object 2 created'
+                    }
+                }
+            }
+        };
+        doc.addPath('/path1', path2)
+        expect(doc.rootDoc.paths['/path1']).eql({...path1, ...path2});
     });
 
     it('addWebhook', () => {

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -99,10 +99,6 @@ export class OpenApiBuilder {
         return this;
     }
     addPath(path: string, pathItem: oa.PathItemObject): OpenApiBuilder {
-        this.rootDoc.paths[path] = pathItem;
-        return this;
-    }
-    mergePath(path: string, pathItem: oa.PathItemObject): OpenApiBuilder {
         this.rootDoc.paths[path] = {...this.rootDoc.paths[path] || {}, ...pathItem};
         return this;
     }

--- a/src/dsl/OpenApiBuilder.ts
+++ b/src/dsl/OpenApiBuilder.ts
@@ -102,6 +102,10 @@ export class OpenApiBuilder {
         this.rootDoc.paths[path] = pathItem;
         return this;
     }
+    mergePath(path: string, pathItem: oa.PathItemObject): OpenApiBuilder {
+        this.rootDoc.paths[path] = {...this.rootDoc.paths[path] || {}, ...pathItem};
+        return this;
+    }
     addSchema(name: string, schema: oa.SchemaObject | oa.ReferenceObject): OpenApiBuilder {
         this.rootDoc.components.schemas[name] = schema;
         return this;


### PR DESCRIPTION
Enable to merge paths.

```typescript
doc.addPath('/users', {
  post: {...}
});

doc.mergePath('/users', {
  get: {...}
});

doc.mergePath('/users', {
  delete: {...}
});

// didn't overwrite "/users" as the "addPath" does, merging with the existing ones
/** result
{
  post: {...}
  get: {...}
  delete: {...}
}

*/

```