### PR TITLE
export SchemaObjectType array

### DIFF
--- a/src/model/OpenApi.ts
+++ b/src/model/OpenApi.ts
@@ -268,7 +268,7 @@ export function isReferenceObject(obj: any): obj is ReferenceObject {
     return Object.prototype.hasOwnProperty.call(obj, '$ref');
 }
 
-type SchemaObjectType = 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array';
+export type SchemaObjectType = 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array';
 
 export interface SchemaObject extends ISpecificationExtension {
     nullable?: boolean;


### PR DESCRIPTION
i would like this type exported so i can stop hardcoding it in some polymorphic schema building functions.