### PR TITLE
4.0: Expose SchemaObjectType for 3.1 model

### DIFF
--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -252,7 +252,7 @@ export function isReferenceObject(obj: any): obj is ReferenceObject {
     return Object.prototype.hasOwnProperty.call(obj, '$ref');
 }
 
-type SchemaObjectType = 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array';
+export type SchemaObjectType = 'integer' | 'number' | 'string' | 'boolean' | 'object' | 'null' | 'array';
 
 export interface SchemaObject extends ISpecificationExtension {
     /** nullable supported in v. 3.1.0 */


### PR DESCRIPTION
`SchemaObjectType` should be exposed in OAS 3.1 model.
OAS 3.0 is OK.

Exposing this interface was the feature of version 3.2.0