### PR TITLE
4.0: Default OpenAPI version should math the builder

### DIFF
--- a/src/dsl/openapi-builder31.ts
+++ b/src/dsl/openapi-builder31.ts
@@ -13,7 +13,7 @@ export class OpenApiBuilder {
 
     constructor(doc?: oa.OpenAPIObject) {
         this.rootDoc = doc || {
-            openapi: '3.0.0',
+            openapi: '3.1.0',
             info: {
                 title: 'app',
                 version: 'version'


### PR DESCRIPTION
Fix for OpenAPI builder of 3.1