### PR TITLE
Refactor to better export oas30 and oas31 compatible with cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,24 @@ Version 4.0 Adds explicit support for OAS 3.0 and OAS 3.1 as separate implementa
 From Typescript you can consume it from the library:
 
 ```typescript
-import { OpenAPIObject, OpenApiBuilder } from "openapi3-ts"; 
+import lib from "openapi3-ts"; 
+
+// And then use: lib.oas31
 ```
 
-Or direclty from the sources:
+Or direclty from sources:
 
 ```typescript
-import { OpenAPIObject, OpenApiBuilder } from "openapi3-ts/src"; 
+import { OpenAPIObject } from "openapi3-ts/src/model/openapi31"; 
+import { OpenApiBuilder } from "openapi3-ts/src/dsl/openapi-builder31"; 
 ```
 
 From a JavaScript application you can import:
 
 ```javascript
-import * as openapi31 from 'openapi3-ts';
- 
+import lib from 'openapi3-ts';
+
+// And then use: lib.oas31 
 ```
 
 ### To use version 3.0 import
@@ -40,8 +44,9 @@ import * as openapi31 from 'openapi3-ts';
 From Typescript you can consume it from the library:
 
 ```typescript
-import { OpenAPIObject } from "openapi3-ts/model/openapi30"; 
-import { OpenApiBuilder } from "openapi3-ts/dsl/openapi-builder30";
+import { oas30 } from "openapi3-ts"; 
+
+// And then use: lib.oas30
 ```
 
 Or directly from the sources:
@@ -54,8 +59,10 @@ import { OpenApiBuilder } from "openapi3-ts/src/dsl/openapi-builder30";
 From a JavaScript application you can import:
 
 ```javascript
-import * as model from 'openapi3-ts/dist/cjs/model/openapi30';
-import * as dsl from 'openapi3-ts/dist/cjs/dsl/openapi-builder30'; 
+import  lib from 'openapi3-ts/dist/cjs';
+// or 'openapi3-ts/dist/mjs'
+
+// And then use: lib.oas30
 ```
 
 ## Includes

--- a/src/dsl/index.ts
+++ b/src/dsl/index.ts
@@ -1,1 +1,2 @@
-export * from './openapi-builder31';
+export * as oas30 from './openapi-builder30';
+export * as oas31 from './openapi-builder31';

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,17 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { OpenApiBuilder, Server, ServerVariable } from '.';
+import lib from './index';
 
 describe('Top barrel', () => {
-    it('OpenApiBuilder is exported', () => {
-        const sut = OpenApiBuilder.create();
+    it('OpenApiBuilder v. 3.0 is exported', () => {
+        const sut = lib.oas30.OpenApiBuilder.create();
+        expect(sut).not.toBeNull;
+    });
+    it('OpenApiBuilder v. 3.1 is exported', () => {
+        const sut = lib.oas31.OpenApiBuilder.create();
         expect(sut).not.toBeNull;
     });
     it('Server is exported', () => {
-        const sut = new Server('a', 'b');
+        const sut = new lib.Server('a', 'b');
         expect(sut).not.toBeNull;
     });
     it('ServerVariable is exported', () => {
-        const sut = new ServerVariable('a', ['b'], 'c');
+        const sut = new lib.ServerVariable('a', ['b'], 'c');
         expect(sut).not.toBeNull;
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,12 @@
-export * from './dsl/index';
-export * from './model/index';
+import * as dsl from './dsl/index';
+import * as model from './model/index';
+
+const oas30 = { ...model.oas30, ...dsl.oas30 };
+const oas31 = { ...model.oas31, ...dsl.oas31 };
+
+export default {
+    oas30,
+    oas31,
+    Server: model.Server,
+    ServerVariable: model.ServerVariable
+};

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,3 +1,4 @@
-export * from './openapi31';
-export * from './server';
-export * from './specification-extension';
+export * as oas30 from './openapi30';
+export * as oas31 from './openapi31';
+export { Server, ServerVariable } from './server';
+export { IExtensionName, IExtensionType, ISpecificationExtension } from './specification-extension';


### PR DESCRIPTION
Refactor to better export oas30 and oas31 compatible with cjs 
(it will break compatibility in the way we export).

Can you take a look @RobinTail is this solves your use case?