### PR TITLE
Fixing exports of namespaces `oas30` and `oas31`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ Version 4.0 Adds explicit support for OAS 3.0 and OAS 3.1 as separate implementa
 From Typescript you can consume it from the library:
 
 ```typescript
-import { OpenAPIObject, OpenApiBuilder } from "openapi3-ts"; 
+import { oas31 } from "openapi3-ts";
 ```
 
-Or direclty from the sources:
+Or directly from sources:
 
 ```typescript
-import { OpenAPIObject, OpenApiBuilder } from "openapi3-ts/src"; 
+import { OpenAPIObject } from "openapi3-ts/src/model/openapi31";
+import { OpenApiBuilder } from "openapi3-ts/src/dsl/openapi-builder31";
 ```
 
 From a JavaScript application you can import:
 
 ```javascript
-import * as openapi31 from 'openapi3-ts';
- 
+import { oas31 } from 'openapi3-ts';
 ```
 
 ### To use version 3.0 import
@@ -40,22 +40,20 @@ import * as openapi31 from 'openapi3-ts';
 From Typescript you can consume it from the library:
 
 ```typescript
-import { OpenAPIObject } from "openapi3-ts/model/openapi30"; 
-import { OpenApiBuilder } from "openapi3-ts/dsl/openapi-builder30";
+import { oas30 } from "openapi3-ts";
 ```
 
 Or directly from the sources:
 
 ```typescript
-import { OpenAPIObject } from "openapi3-ts/src/model/openapi30"; 
-import { OpenApiBuilder } from "openapi3-ts/src/dsl/openapi-builder30"; 
+import { OpenAPIObject } from "openapi3-ts/src/model/openapi30";
+import { OpenApiBuilder } from "openapi3-ts/src/dsl/openapi-builder30";
 ```
 
 From a JavaScript application you can import:
 
 ```javascript
-import * as model from 'openapi3-ts/dist/cjs/model/openapi30';
-import * as dsl from 'openapi3-ts/dist/cjs/dsl/openapi-builder30'; 
+import { oas30 } from "openapi3-ts";
 ```
 
 ## Includes

--- a/src/dsl/index.ts
+++ b/src/dsl/index.ts
@@ -1,1 +1,0 @@
-export * from './openapi-builder31';

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { OpenApiBuilder, Server, ServerVariable } from '.';
+import { oas30, oas31, Server, ServerVariable } from '.';
 
 describe('Top barrel', () => {
-    it('OpenApiBuilder is exported', () => {
-        const sut = OpenApiBuilder.create();
+    it('OpenApiBuilder v. 3.0 is exported', () => {
+        const sut = oas30.OpenApiBuilder.create();
+        expect(sut).not.toBeNull;
+    });
+    it('OpenApiBuilder v. 3.1 is exported', () => {
+        const sut = oas31.OpenApiBuilder.create();
         expect(sut).not.toBeNull;
     });
     it('Server is exported', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -5,10 +5,12 @@ describe('Top barrel', () => {
     it('OpenApiBuilder v. 3.0 is exported', () => {
         const sut = oas30.OpenApiBuilder.create();
         expect(sut).not.toBeNull;
+        expect(sut.rootDoc.openapi).toBe("3.0.0");
     });
     it('OpenApiBuilder v. 3.1 is exported', () => {
         const sut = oas31.OpenApiBuilder.create();
         expect(sut).not.toBeNull;
+        expect(sut.rootDoc.openapi).toBe("3.1.0");
     });
     it('Server is exported', () => {
         const sut = new Server('a', 'b');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export * from './dsl/index';
-export * from './model/index';
+export * as oas30 from "./oas30";
+export * as oas31 from "./oas31";
+export { Server, ServerVariable } from "./model/server"

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,3 +1,0 @@
-export * from './openapi31';
-export * from './server';
-export * from './specification-extension';

--- a/src/oas30.ts
+++ b/src/oas30.ts
@@ -1,0 +1,4 @@
+export * from './dsl/openapi-builder30';
+export * from './model/openapi30';
+export { Server, ServerVariable } from './model/server';
+export { IExtensionName, IExtensionType, ISpecificationExtension } from './model/specification-extension';

--- a/src/oas31.ts
+++ b/src/oas31.ts
@@ -1,0 +1,4 @@
+export * from './dsl/openapi-builder31';
+export * from './model/openapi31';
+export { Server, ServerVariable } from './model/server';
+export { IExtensionName, IExtensionType, ISpecificationExtension } from './model/specification-extension';


### PR DESCRIPTION
Alternative solution to #103.

Closes #98 

Explainted here: https://github.com/metadevpro/openapi3-ts/pull/103#issuecomment-1489074420