### PR TITLE
fix: remove any type

### DIFF
--- a/src/dsl/openapi-builder31.ts
+++ b/src/dsl/openapi-builder31.ts
@@ -99,7 +99,7 @@ export class OpenApiBuilder {
         return this;
     }
     addPath(path: string, pathItem: oa.PathItemObject): OpenApiBuilder {
-        this.rootDoc.paths = this.rootDoc.paths || [];
+        this.rootDoc.paths = this.rootDoc.paths || {};
         this.rootDoc.paths[path] = { ...(this.rootDoc.paths[path] || {}), ...pathItem };
         return this;
     }

--- a/src/model/openapi30.ts
+++ b/src/model/openapi30.ts
@@ -55,7 +55,7 @@ export interface ComponentsObject extends ISpecificationExtension {
  */
 export interface PathsObject extends ISpecificationExtension {
     // [path: string]: PathItemObject;
-    [path: string]: PathItemObject | any; // Hack for allowing ISpecificationExtension
+    [path: string]: PathItemObject
 }
 
 /**

--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -57,7 +57,7 @@ export interface ComponentsObject extends ISpecificationExtension {
  */
 export interface PathsObject extends ISpecificationExtension {
     // [path: string]: PathItemObject;
-    [path: string]: PathItemObject | any; // Hack for allowing ISpecificationExtension
+    [path: string]: PathItemObject
 }
 
 /**


### PR DESCRIPTION
The `any` disables any Intellisense in the editors as the `any` overrides the overall type.

Before:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/18017094/229352898-6c11203c-c53f-4862-96a0-2e600316b35b.png">

After:
<img width="564" alt="image" src="https://user-images.githubusercontent.com/18017094/229352875-dd6409ca-a2ed-45cf-a050-48722c307357.png">

I noticed there's quite a number of these throughout the codebase. Is it still required given we already have the new ISpecificationExtension interface? Shall I do a cleanup?