### PR TITLE
Fix Up Types

### DIFF
--- a/src/model/openapi30.ts
+++ b/src/model/openapi30.ts
@@ -308,7 +308,6 @@ export interface SchemaObject extends ISpecificationExtension {
     minProperties?: number;
     required?: string[];
     enum?: any[];
-    prefixItems?: (SchemaObject | ReferenceObject)[];
 }
 
 /**

--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -269,10 +269,6 @@ export interface SchemaObject extends ISpecificationExtension {
     writeOnly?: boolean;
     xml?: XmlObject;
     externalDocs?: ExternalDocumentationObject;
-    /**
-     * |@deprecated Deprecated in v.3.1.0 in favour of examples
-     * */
-    example?: any;
     examples?: any[];
     deprecated?: boolean;
 
@@ -316,6 +312,7 @@ export interface SchemaObject extends ISpecificationExtension {
     minProperties?: number;
     required?: string[];
     enum?: any[];
+    prefixItems?: (SchemaObject | ReferenceObject)[];
 }
 
 /**


### PR DESCRIPTION
During the split `prefixItems` ended up in the wrong version. It belongs in 3.1.
`example` is invalid in 3.1 so we should just remove it from the 3.1 definition right?