### PR TITLE
fix: Modify ReferenceObject in OAS 3.1

### DIFF
--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -240,6 +240,8 @@ export interface ExamplesObject {
 
 export interface ReferenceObject {
     $ref: string;
+    summary?: string;
+    description?: string;
 }
 
 /**


### PR DESCRIPTION
Hi there, RefrenceObject has additional optional properties `summary` and `description` in OAS3.1. https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object