### PR TITLE
feat: Export ./oas30 and ./oas31

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ Version 4.0 Adds explicit support for OAS 3.0 and OAS 3.1 as separate implementa
 From Typescript you can consume it from the library:
 
 ```typescript
-import { oas31 } from "openapi3-ts";
+import { oas31 } from 'openapi3-ts';
 ```
 
-Or directly from sources:
+Or directly named import:
 
 ```typescript
-import { OpenAPIObject } from "openapi3-ts/src/model/openapi31";
-import { OpenApiBuilder } from "openapi3-ts/src/dsl/openapi-builder31";
+import { OpenAPIObject, OpenApiBuilder } from 'openapi3-ts/oas31';
 ```
 
 From a JavaScript application you can import:
@@ -40,20 +39,19 @@ import { oas31 } from 'openapi3-ts';
 From Typescript you can consume it from the library:
 
 ```typescript
-import { oas30 } from "openapi3-ts";
+import { oas30 } from 'openapi3-ts';
 ```
 
-Or directly from the sources:
+Or directly named import:
 
 ```typescript
-import { OpenAPIObject } from "openapi3-ts/src/model/openapi30";
-import { OpenApiBuilder } from "openapi3-ts/src/dsl/openapi-builder30";
+import { OpenAPIObject, OpenApiBuilder } from 'openapi3-ts/oas30';
 ```
 
 From a JavaScript application you can import:
 
 ```javascript
-import { oas30 } from "openapi3-ts";
+import { oas30 } from 'openapi3-ts';
 ```
 
 ## Includes

--- a/package.json
+++ b/package.json
@@ -5,6 +5,20 @@
     "main": "dist/cjs/index.js",
     "module": "dist/mjs/index.js",
     "typings": "dist/mjs/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/mjs/index.js",
+        "require": "./dist/cjs/index.js"
+      },
+      "./oas30": {
+        "import": "./dist/mjs/oas30.js",
+        "require": "./dist/cjs/oas30.js"
+      },
+      "./oas31": {
+        "import": "./dist/mjs/oas31.js",
+        "require": "./dist/cjs/oas31.js"
+      }
+    },
     "repository": {
         "type": "git",
         "url": "https://github.com/metadevpro/openapi3-ts.git"


### PR DESCRIPTION
Hi there, this is a proposal for import syntax for compatibility with v3 code. It is helpful since we can upgrade openapi3-ts without code changes like `oas31.OpenAPIObject`.

```js
// Both are ok
import { oas31 } from 'openapi3-ts';
import { OpenAPIObject, OpenApiBuilder } from 'openapi3-ts/oas31';
```

Also, it would fix #107