### PR TITLE
Flip Deprecation on example and nullable in 3.1.0

### DIFF
--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -264,13 +264,13 @@ export type SchemaObjectType =
     | 'array';
 
 export interface SchemaObject extends ISpecificationExtension {
-    /** nullable supported in v. 3.1.0 */
-    nullable?: boolean;
     discriminator?: DiscriminatorObject;
     readOnly?: boolean;
     writeOnly?: boolean;
     xml?: XmlObject;
     externalDocs?: ExternalDocumentationObject;
+    /** @deprecated use examples instead */
+    example?: any;
     examples?: any[];
     deprecated?: boolean;
 


### PR DESCRIPTION
I made a mistake in the last PR. It's `nullable` which is entirely removed and `example` which is deprecated. I get them mixed up, my bad.

https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/18017094/232178460-ffa0e4fb-e0e2-439f-bf53-b6775d58791d.png">

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/18017094/232178469-d53ab7c5-76d8-42b0-b557-52e6820a5d73.png">


