### PR TITLE
Fix `nullable` on 3.0 types

### DIFF
--- a/src/model/openapi30.ts
+++ b/src/model/openapi30.ts
@@ -269,6 +269,7 @@ export type SchemaObjectFormat =
     | string;
 
 export interface SchemaObject extends ISpecificationExtension {
+    nullable?: boolean;
     discriminator?: DiscriminatorObject;
     readOnly?: boolean;
     writeOnly?: boolean;


### PR DESCRIPTION
Where did `nullable` go in the 3.0 types? 😅 

Sorry for noticing this late, I'm working on splitting out my hybrid type repo