### PR TITLE
Correct LicenseObject

### DIFF
--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -36,6 +36,7 @@ export interface ContactObject extends ISpecificationExtension {
 }
 export interface LicenseObject extends ISpecificationExtension {
     name: string;
+    identifier?: string;
     url?: string;
 }
 


### PR DESCRIPTION
Added `identifier` according to the spec:
https://swagger.io/specification/#license-object