### PR TITLE
Fix for 3.1: `const` is `any`, not only `string`

### DIFF
--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -301,7 +301,7 @@ export interface SchemaObject extends ISpecificationExtension {
     title?: string;
     multipleOf?: number;
     maximum?: number;
-    const?: string;
+    const?: any;
     /** @desc In OpenAPI 3.1: number */
     exclusiveMaximum?: number;
     minimum?: number;


### PR DESCRIPTION
Fixes #132 

See https://json-schema.org/draft-06/draft-wright-json-schema-validation-01#rfc.section.6.24

![2024-04-01_11-10-22](https://github.com/metadevpro/openapi3-ts/assets/13189514/57743799-45b5-4e21-a633-ddfe3750d105)
