### PR TITLE
fix: use Record for properties field in Schema Object

### DIFF
--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -292,7 +292,7 @@ export interface SchemaObject extends ISpecificationExtension {
     anyOf?: (SchemaObject | ReferenceObject)[];
     not?: SchemaObject | ReferenceObject;
     items?: SchemaObject | ReferenceObject;
-    properties?: Record<string, SchemaObject | ReferenceObject>;
+    properties?: Partial<Record<string, SchemaObject | ReferenceObject>>;
     additionalProperties?: SchemaObject | ReferenceObject | boolean;
     propertyNames?: SchemaObject | ReferenceObject;
     description?: string;

--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -292,7 +292,7 @@ export interface SchemaObject extends ISpecificationExtension {
     anyOf?: (SchemaObject | ReferenceObject)[];
     not?: SchemaObject | ReferenceObject;
     items?: SchemaObject | ReferenceObject;
-    properties?: { [propertyName: string]: SchemaObject | ReferenceObject };
+    properties?: Record<string, SchemaObject | ReferenceObject>;
     additionalProperties?: SchemaObject | ReferenceObject | boolean;
     propertyNames?: SchemaObject | ReferenceObject;
     description?: string;


### PR DESCRIPTION
Using mapped types like `{ [propertyName: string]: SchemaObject | ReferenceObject }` doesn't ensure the key to be of type `string`. Instead, TypeScript interprets the key as `string | number`.

<img width="466" alt="image" src="https://github.com/metadevpro/openapi3-ts/assets/47082523/ab56d5fa-32e5-459b-950c-043a36051eb7">


This behaviour can be verified in the following [playground](https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgMpiqA5gOQK4C2AsnAA7IDeAUMsgNoDOG2A0hAJ4BcyTmIWAXW4hCAI2i0qAXypUw7UijbsA8jHR9chEuQC8yANYcA9jDTN++YmSoB6W7WQA9ZGAAWKI+2TAGyU64KKADkvNjIAD7IIgTiUMEAND4gTBBwACb+ZsYgADbeoRZYwbIIOUw8cASkuRDK3MpqGthWOsj6AIwATADMdg6Og0PDI6POrm6+PG7GeLnpIMFgyOLIcLm5xgDuEOlUQA)



Due to this issue, if you iterate over the properties of a schema, TypeScript can't be sure that the key is of type `string`. Instead the key will be interpreted as of type `string | number`.

Using a `Record` allows to strictly type the key to only be of type `string`, which can be verified [here](https://www.typescriptlang.org/play/?#code/C4TwDgpgBAysBOBLAdgcwHIFcC2BZAhmFALxQAK+8wi+ANgDwBKEAxgPbwAm9AzgiqgA0UZDgBGEeAD4pAKFmhIUANIQQAeQBmcJGix5CJKAGs1bTbH56cBMLID09qM4B6UYAAtopkFEQ8oOgB3fBAA83dwaAByPl1UaJE2IOcoeXZkPigefGwwWghVEAAuFTUtHQF9WyMARgAmAGYHJ1S29o7OrqgXT38-HmRo4Gc6WmSITkDkEGwOCFkgA)

<img width="466" alt="image" src="https://github.com/metadevpro/openapi3-ts/assets/47082523/434d41fd-d140-4a95-b37c-b092c8be3cb3">



It's a known TypeScript issue https://github.com/microsoft/TypeScript/issues/48269
