### PR TITLE
Allow $ref in OpenAPI 3.1.0 SchemaObjects

### DIFF
--- a/src/model/openapi31.ts
+++ b/src/model/openapi31.ts
@@ -265,6 +265,7 @@ export type SchemaObjectType =
     | 'array';
 
 export interface SchemaObject extends ISpecificationExtension {
+    $ref?: string,
     discriminator?: DiscriminatorObject;
     readOnly?: boolean;
     writeOnly?: boolean;


### PR DESCRIPTION
https://spec.openapis.org/oas/v3.1.0.html#reference-object

Mentions that Schema Objects can have $ref

