### PR TITLE
Add OpenAPI 3.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ TypeScript library to help building OpenAPI 3.x compliant API contracts.
 
 Version 4.0 Adds explicit support for OAS 3.0 and OAS 3.1 as separate implementations.
 
+OAS 3.2 is available as a third parallel implementation (`oas32`). The JSON Schema dialect is unchanged between 3.1 and 3.2 (Draft 2020-12); 3.2 adds document-structure fields such as streaming `itemSchema`/`itemEncoding`/`prefixEncoding` on the Media Type Object, the reusable `mediaTypes` component bucket, the `query` HTTP method and `additionalOperations`, Tag hierarchies, the XML `nodeType`, and the OAuth device authorization flow.
+
+### To use version 3.2 import
+
+```js
+import { oas32 } from 'openapi3-ts';
+```
+
+Or directly import from subpath:
+
+```js
+import { OpenAPIObject, OpenApiBuilder } from 'openapi3-ts/oas32';
+```
+
 ### To use version 3.1 import
 
 ```js
@@ -58,6 +72,7 @@ npm i --save openapi3-ts
 
 ## References
 
+* OpenAPI spec 3.2.0. [https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md)
 * OpenAPI spec 3.1.0. [https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.1.0.md)
 
 ## License

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The builder pattern, the TS compiler & the code-completion will guide you to add
 Minimal example to generate a 3.1 OAS compliant document:
 
 ```typescript
-import { OpenApiBuilder } from 'openapi3-ts/oas31'; // Pick `openapi3-ts/oas31` for 3.1.x (x)or pick `openapi3-ts/oas30` for 3.0.x
+import { OpenApiBuilder } from 'openapi3-ts/oas31'; // Pick `openapi3-ts/oas32` for 3.2.x, `openapi3-ts/oas31` for 3.1.x, (x)or `openapi3-ts/oas30` for 3.0.x
 
 function buildOas() {
     const builder = OpenApiBuilder

--- a/oas32.d.ts
+++ b/oas32.d.ts
@@ -1,0 +1,2 @@
+// To support envs which cannot interpret "exports" field in package.json. e.g. tsc with "moduleResolution": "node"
+export * from './dist/oas32'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
             "types": "./dist/oas31.d.ts",
             "import": "./dist/oas31.mjs",
             "require": "./dist/oas31.js"
+        },
+        "./oas32": {
+            "types": "./dist/oas32.d.ts",
+            "import": "./dist/oas32.mjs",
+            "require": "./dist/oas32.js"
         }
     },
     "repository": {
@@ -72,6 +77,7 @@
         "dist",
         "*.md",
         "oas30.d.ts",
-        "oas31.d.ts"
+        "oas31.d.ts",
+        "oas32.d.ts"
     ]
 }

--- a/src/dsl/openapi-builder32.spec.ts
+++ b/src/dsl/openapi-builder32.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import * as oa from '../model/openapi32';
+import { OpenApiBuilder } from './openapi-builder32';
+
+describe('OpenApiBuilder 3.2', () => {
+    it('Build empty Spec', () => {
+        expect(OpenApiBuilder.create().getSpec()).eql({
+            openapi: '3.2.0',
+            info: {
+                title: 'app',
+                version: 'version'
+            },
+            paths: {},
+            components: {
+                schemas: {},
+                responses: {},
+                parameters: {},
+                examples: {},
+                requestBodies: {},
+                headers: {},
+                securitySchemes: {},
+                links: {},
+                callbacks: {}
+            },
+            tags: [],
+            servers: []
+        });
+    });
+    it('Build with custom object', () => {
+        const obj: oa.OpenAPIObject = {
+            openapi: '3.2.0',
+            $self: 'https://example.com/openapi.json',
+            info: {
+                title: 'app1',
+                version: 'version2'
+            },
+            paths: {},
+            components: {},
+            tags: [],
+            servers: []
+        };
+        expect(OpenApiBuilder.create(obj).getSpec()).eql(obj);
+    });
+    it('addOpenApiVersion 3.2', () => {
+        const sut = OpenApiBuilder.create().addOpenApiVersion('3.2.0').rootDoc;
+        expect(sut.openapi).eql('3.2.0');
+    });
+    it('addTitle', () => {
+        const sut = OpenApiBuilder.create().addTitle('app7').rootDoc;
+        expect(sut.info.title).eql('app7');
+    });
+    it('addServer with name', () => {
+        const sut = OpenApiBuilder.create().addServer({
+            url: 'https://api.example.com',
+            name: 'production'
+        }).rootDoc;
+        expect(sut.servers?.[0]).eql({ url: 'https://api.example.com', name: 'production' });
+    });
+    it('addSchema', () => {
+        const sut = OpenApiBuilder.create().addSchema('Pet', { type: 'object' }).rootDoc;
+        expect(sut.components?.schemas?.Pet).eql({ type: 'object' });
+    });
+    it('addResponse', () => {
+        const sut = OpenApiBuilder.create().addResponse('Created', { summary: 'Created' }).rootDoc;
+        expect(sut.components?.responses?.Created).eql({ summary: 'Created' });
+    });
+    it('addTag with hierarchy', () => {
+        const sut = OpenApiBuilder.create().addTag({
+            name: 'partner',
+            summary: 'Partner',
+            parent: 'external',
+            kind: 'audience'
+        }).rootDoc;
+        expect(sut.tags?.[0]).eql({
+            name: 'partner',
+            summary: 'Partner',
+            parent: 'external',
+            kind: 'audience'
+        });
+    });
+    it('getSpecAsJson / getSpecAsYaml', () => {
+        const sut = OpenApiBuilder.create().addTitle('app').rootDoc;
+        const json = OpenApiBuilder.create(sut).getSpecAsJson();
+        expect(JSON.parse(json).openapi).eql('3.2.0');
+        const yaml = OpenApiBuilder.create(sut).getSpecAsYaml();
+        expect(yaml).contains('openapi: 3.2.0');
+    });
+
+    // Exercises the OAS 3.2 document-structure additions through a realistic document.
+    // This is primarily a compile-time type check (the object is typed as OpenAPIObject),
+    // round-tripped through the builder to confirm the fields survive serialization.
+    it('accepts a document exercising the OAS 3.2 additions', () => {
+        const doc: oa.OpenAPIObject = {
+            openapi: '3.2.0',
+            $self: 'https://example.com/openapi.json', // root $self
+            jsonSchemaDialect: 'https://spec.openapis.org/oas/3.1/dialect/base',
+            info: { title: 'app', summary: 'A short summary', version: '1.0.0' },
+            servers: [{ url: 'https://api.example.com', name: 'production' }], // Server.name
+            tags: [
+                { name: 'external', summary: 'External', kind: 'audience' },
+                { name: 'partner', summary: 'Partner', parent: 'external', kind: 'audience' } // Tag hierarchy
+            ],
+            components: {
+                // reusable Media Type bucket with streaming itemSchema
+                mediaTypes: {
+                    EventStream: {
+                        itemSchema: { $ref: '#/components/schemas/AgentSSEEvent' }
+                    }
+                },
+                schemas: {
+                    Shape: {
+                        oneOf: [{ $ref: '#/components/schemas/Cat' }],
+                        discriminator: {
+                            propertyName: 'kind',
+                            mapping: { cat: '#/components/schemas/Cat' },
+                            defaultMapping: '#/components/schemas/Unknown' // Discriminator.defaultMapping
+                        },
+                        xml: { nodeType: 'element', name: 'shape' } // XML.nodeType
+                    }
+                },
+                securitySchemes: {
+                    oauthDevice: {
+                        type: 'oauth2',
+                        oauth2MetadataUrl: 'https://example.com/.well-known/oauth-authorization-server',
+                        deprecated: false,
+                        flows: {
+                            deviceAuthorization: {
+                                deviceAuthorizationUrl: 'https://example.com/device',
+                                tokenUrl: 'https://example.com/token',
+                                scopes: { 'read:data': 'Read data' }
+                            }
+                        }
+                    },
+                    mtls: { type: 'mutualTLS' }
+                }
+            },
+            paths: {
+                '/items': {
+                    query: { responses: {} }, // QUERY method
+                    additionalOperations: { LOCK: { responses: {} } }, // additionalOperations
+                    parameters: [
+                        // querystring location + content
+                        {
+                            name: 'qs',
+                            in: 'querystring',
+                            content: { 'application/x-www-form-urlencoded': {} }
+                        },
+                        { name: 'session', in: 'cookie', style: 'cookie' } // cookie style
+                    ],
+                    post: {
+                        requestBody: {
+                            content: {
+                                // content map value as a Reference Object (3.2)
+                                'text/event-stream': { $ref: '#/components/mediaTypes/EventStream' }
+                            }
+                        },
+                        responses: {
+                            // Response with summary and no description (description optional in 3.2)
+                            '201': {
+                                summary: 'Created',
+                                content: {
+                                    'application/json': {
+                                        examples: {
+                                            sample: {
+                                                dataValue: { id: 1 }, // Example.dataValue
+                                                serializedValue: 'id=1' // Example.serializedValue
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const json = OpenApiBuilder.create(doc).getSpecAsJson();
+        const parsed = JSON.parse(json);
+        expect(parsed.$self).eql('https://example.com/openapi.json');
+        expect(parsed.paths['/items'].query).toBeDefined();
+        expect(parsed.paths['/items'].additionalOperations.LOCK).toBeDefined();
+        expect(parsed.components.mediaTypes.EventStream.itemSchema.$ref).eql(
+            '#/components/schemas/AgentSSEEvent'
+        );
+        expect(parsed.components.schemas.Shape.discriminator.defaultMapping).eql(
+            '#/components/schemas/Unknown'
+        );
+        expect(
+            parsed.components.securitySchemes.oauthDevice.flows.deviceAuthorization
+                .deviceAuthorizationUrl
+        ).eql('https://example.com/device');
+        expect(parsed.paths['/items'].post.responses['201'].summary).eql('Created');
+    });
+});

--- a/src/dsl/openapi-builder32.ts
+++ b/src/dsl/openapi-builder32.ts
@@ -1,0 +1,188 @@
+import * as yaml from 'yaml';
+import * as oa from '../model/openapi32';
+
+// Internal DSL for building an OpenAPI 3.2.x contract
+// using a fluent interface
+
+export class OpenApiBuilder {
+    rootDoc: oa.OpenAPIObject;
+
+    static create(doc?: oa.OpenAPIObject): OpenApiBuilder {
+        return new OpenApiBuilder(doc);
+    }
+
+    constructor(doc?: oa.OpenAPIObject) {
+        this.rootDoc = doc || {
+            openapi: '3.2.0',
+            info: {
+                title: 'app',
+                version: 'version'
+            },
+            paths: {},
+            components: {
+                schemas: {},
+                responses: {},
+                parameters: {},
+                examples: {},
+                requestBodies: {},
+                headers: {},
+                securitySchemes: {},
+                links: {},
+                callbacks: {}
+            },
+            tags: [],
+            servers: []
+        };
+    }
+
+    getSpec(): oa.OpenAPIObject {
+        return this.rootDoc;
+    }
+
+    getSpecAsJson(
+        replacer?: (key: string, value: unknown) => unknown,
+        space?: string | number
+    ): string {
+        return JSON.stringify(this.rootDoc, replacer, space);
+    }
+    getSpecAsYaml(
+        replacer?: Parameters<typeof yaml.stringify>[1],
+        options?: Parameters<typeof yaml.stringify>[2]
+    ): string {
+        return yaml.stringify(this.rootDoc, replacer, options);
+    }
+
+    private static isValidOpenApiVersion(v: string): boolean {
+        v = v || '';
+        const match = /(\d+)\.(\d+).(\d+)/.exec(v);
+        if (match) {
+            const major = parseInt(match[1], 10);
+            if (major >= 3) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    addOpenApiVersion(openApiVersion: string): OpenApiBuilder {
+        if (!OpenApiBuilder.isValidOpenApiVersion(openApiVersion)) {
+            throw new Error(
+                'Invalid OpenApi version: ' + openApiVersion + '. Follow convention: 3.x.y'
+            );
+        }
+        this.rootDoc.openapi = openApiVersion;
+        return this;
+    }
+    addInfo(info: oa.InfoObject): OpenApiBuilder {
+        this.rootDoc.info = info;
+        return this;
+    }
+    addContact(contact: oa.ContactObject): OpenApiBuilder {
+        this.rootDoc.info.contact = contact;
+        return this;
+    }
+    addLicense(license: oa.LicenseObject): OpenApiBuilder {
+        this.rootDoc.info.license = license;
+        return this;
+    }
+    addTitle(title: string): OpenApiBuilder {
+        this.rootDoc.info.title = title;
+        return this;
+    }
+    addDescription(description: string): OpenApiBuilder {
+        this.rootDoc.info.description = description;
+        return this;
+    }
+    addTermsOfService(termsOfService: string): OpenApiBuilder {
+        this.rootDoc.info.termsOfService = termsOfService;
+        return this;
+    }
+    addVersion(version: string): OpenApiBuilder {
+        this.rootDoc.info.version = version;
+        return this;
+    }
+    addPath(path: string, pathItem: oa.PathItemObject): OpenApiBuilder {
+        this.rootDoc.paths = this.rootDoc.paths || {};
+        this.rootDoc.paths[path] = { ...(this.rootDoc.paths[path] || {}), ...pathItem };
+        return this;
+    }
+    addSchema(name: string, schema: oa.SchemaObject | oa.ReferenceObject): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.schemas = this.rootDoc.components.schemas || {};
+        this.rootDoc.components.schemas[name] = schema;
+        return this;
+    }
+    addResponse(name: string, response: oa.ResponseObject | oa.ReferenceObject): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.responses = this.rootDoc.components.responses || {};
+        this.rootDoc.components.responses[name] = response;
+        return this;
+    }
+    addParameter(name: string, parameter: oa.ParameterObject | oa.ReferenceObject): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.parameters = this.rootDoc.components.parameters || {};
+        this.rootDoc.components.parameters[name] = parameter;
+        return this;
+    }
+    addExample(name: string, example: oa.ExampleObject | oa.ReferenceObject): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.examples = this.rootDoc.components.examples || {};
+        this.rootDoc.components.examples[name] = example;
+        return this;
+    }
+    addRequestBody(
+        name: string,
+        reqBody: oa.RequestBodyObject | oa.ReferenceObject
+    ): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.requestBodies = this.rootDoc.components.requestBodies || {};
+        this.rootDoc.components.requestBodies[name] = reqBody;
+        return this;
+    }
+    addHeader(name: string, header: oa.HeaderObject | oa.ReferenceObject): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.headers = this.rootDoc.components.headers || {};
+        this.rootDoc.components.headers[name] = header;
+        return this;
+    }
+    addSecurityScheme(
+        name: string,
+        secScheme: oa.SecuritySchemeObject | oa.ReferenceObject
+    ): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.securitySchemes = this.rootDoc.components.securitySchemes || {};
+        this.rootDoc.components.securitySchemes[name] = secScheme;
+        return this;
+    }
+    addLink(name: string, link: oa.LinkObject | oa.ReferenceObject): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.links = this.rootDoc.components.links || {};
+        this.rootDoc.components.links[name] = link;
+        return this;
+    }
+    addCallback(name: string, callback: oa.CallbackObject | oa.ReferenceObject): OpenApiBuilder {
+        this.rootDoc.components = this.rootDoc.components || {};
+        this.rootDoc.components.callbacks = this.rootDoc.components.callbacks || {};
+        this.rootDoc.components.callbacks[name] = callback;
+        return this;
+    }
+    addServer(server: oa.ServerObject): OpenApiBuilder {
+        this.rootDoc.servers = this.rootDoc.servers || [];
+        this.rootDoc.servers.push(server);
+        return this;
+    }
+    addTag(tag: oa.TagObject): OpenApiBuilder {
+        this.rootDoc.tags = this.rootDoc.tags || [];
+        this.rootDoc.tags.push(tag);
+        return this;
+    }
+    addExternalDocs(extDoc: oa.ExternalDocumentationObject): OpenApiBuilder {
+        this.rootDoc.externalDocs = extDoc;
+        return this;
+    }
+    addWebhook(webhook: string, webhookItem: oa.PathItemObject): OpenApiBuilder {
+        this.rootDoc.webhooks ??= {};
+        this.rootDoc.webhooks[webhook] = webhookItem;
+        return this;
+    }
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { oas30, oas31, Server, ServerVariable } from '.';
+import { oas30, oas31, oas32, Server, ServerVariable } from '.';
 
 describe('Top barrel', () => {
     it('OpenApiBuilder v. 3.0 is exported', () => {
@@ -11,6 +11,11 @@ describe('Top barrel', () => {
         const sut = oas31.OpenApiBuilder.create();
         expect(sut).not.toBeNull();
         expect(sut.rootDoc.openapi).toBe('3.1.0');
+    });
+    it('OpenApiBuilder v. 3.2 is exported', () => {
+        const sut = oas32.OpenApiBuilder.create();
+        expect(sut).not.toBeNull();
+        expect(sut.rootDoc.openapi).toBe('3.2.0');
     });
     it('Server is exported', () => {
         const sut = new Server('a', 'b');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * as oas30 from "./oas30";
 export * as oas31 from "./oas31";
+export * as oas32 from "./oas32";
 export { Server, ServerVariable } from "./model/server"

--- a/src/model/openapi32.spec.ts
+++ b/src/model/openapi32.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+    ReferenceObject,
+    SchemaObject,
+    SchemaObjectValue,
+    addExtension,
+    isReferenceObject,
+    isSchemaObject
+} from './openapi32';
+import { IExtensionName, IExtensionType } from './specification-extension';
+
+describe('type-guards unit tests', () => {
+    describe('isSchemaObject()', () => {
+        it('returns true for a schema object', () => {
+            const schemaObject = new TestSchemaObject();
+            expect(isSchemaObject(schemaObject)).toBe(true);
+        });
+
+        it('returns false for a reference object', () => {
+            const referenceObject = new TestReferenceObject();
+            expect(isSchemaObject(referenceObject)).toBe(false);
+        });
+    });
+
+    describe('isReferenceObject()', () => {
+        it('returns true for a reference object', () => {
+            const referenceObject = new TestReferenceObject();
+            expect(isReferenceObject(referenceObject)).toBe(true);
+        });
+
+        it('returns false for a schema object', () => {
+            const schemaObject = new TestSchemaObject();
+            expect(isReferenceObject(schemaObject)).toBe(false);
+        });
+    });
+});
+
+describe('addExtension()', () => {
+    it('valid extension', () => {
+        const subject = {};
+        addExtension(subject, 'x-extension1', 'myvalue');
+        expect(subject['x-extension1']).toBe('myvalue');
+    });
+    it('invalid extension', () => {
+        const subject = {};
+        addExtension(subject, 'ZZ-extension1', 'myvalue');
+        expect(subject['ZZ-extension1']).not.toBe('myvalue');
+    });
+});
+
+describe('SchemaObject', () => {
+    it('accepts boolean schemas and JSON Schema 2020-12 vocabulary keywords', () => {
+        const alwaysValid: SchemaObject = true;
+        const schema: SchemaObjectValue = {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            $id: 'https://example.com/schemas/node',
+            $dynamicAnchor: 'node',
+            type: 'object',
+            properties: {
+                id: { type: 'string' },
+                child: { $dynamicRef: '#node' },
+                metadata: true
+            },
+            if: { required: ['kind'] },
+            then: { properties: { kind: { const: 'node' } } },
+            unevaluatedProperties: false,
+            customVocabularyKeyword: { enabled: true }
+        };
+
+        expect(isSchemaObject(alwaysValid)).toBe(true);
+        expect(schema.$dynamicAnchor).toBe('node');
+        expect(schema.unevaluatedProperties).toBe(false);
+        expect(schema.customVocabularyKeyword).toEqual({ enabled: true });
+    });
+});
+
+class TestSchemaObject implements SchemaObjectValue {
+    [keyword: string]: unknown;
+    [k: IExtensionName]: IExtensionType;
+    // empty schema
+}
+
+class TestReferenceObject implements ReferenceObject {
+    $ref = 'test';
+}

--- a/src/model/openapi32.ts
+++ b/src/model/openapi32.ts
@@ -1,0 +1,531 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Typed interfaces for OpenAPI 3.2.0
+// see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md
+
+import { ServerVariableObject } from './oas-common';
+import { ISpecificationExtension, SpecificationExtension } from './specification-extension';
+
+export { getExtension, addExtension } from './oas-common';
+export type { ServerVariableObject } from './oas-common';
+export type { ISpecificationExtension, SpecificationExtension } from './specification-extension';
+
+/**
+ * Server Object.
+ *
+ * Defined here (rather than re-exported from `oas-common`) because OAS 3.2 adds the
+ * `name` field, which is not part of the shared 3.0/3.1 Server Object.
+ * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#server-object
+ */
+export interface ServerObject extends ISpecificationExtension {
+    url: string;
+    description?: string;
+    /** @since OAS 3.2 An optional unique string to refer to the host designated by the URL. */
+    name?: string;
+    variables?: { [v: string]: ServerVariableObject };
+}
+
+export interface OpenAPIObject extends ISpecificationExtension {
+    openapi: string;
+    /**
+     * @since OAS 3.2 The self-assigned URI of this document (RFC3986 URI-reference),
+     * which also serves as its base URI for resolving relative references.
+     */
+    $self?: string;
+    info: InfoObject;
+    /** The default value for the `$schema` keyword within Schema Objects in this document (URI). */
+    jsonSchemaDialect?: string;
+    servers?: ServerObject[];
+    paths?: PathsObject;
+    components?: ComponentsObject;
+    security?: SecurityRequirementObject[];
+    tags?: TagObject[];
+    externalDocs?: ExternalDocumentationObject;
+    /** Webhooks added in v. 3.1.0 */
+    webhooks?: PathsObject;
+}
+export interface InfoObject extends ISpecificationExtension {
+    title: string;
+    /** A short summary of the API. */
+    summary?: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: ContactObject;
+    license?: LicenseObject;
+    version: string;
+}
+export interface ContactObject extends ISpecificationExtension {
+    name?: string;
+    url?: string;
+    email?: string;
+}
+export interface LicenseObject extends ISpecificationExtension {
+    name: string;
+    identifier?: string;
+    url?: string;
+}
+
+export interface ComponentsObject extends ISpecificationExtension {
+    schemas?: { [schema: string]: SchemaObject | ReferenceObject };
+    responses?: { [response: string]: ResponseObject | ReferenceObject };
+    parameters?: { [parameter: string]: ParameterObject | ReferenceObject };
+    examples?: { [example: string]: ExampleObject | ReferenceObject };
+    requestBodies?: { [request: string]: RequestBodyObject | ReferenceObject };
+    headers?: { [header: string]: HeaderObject | ReferenceObject };
+    securitySchemes?: { [securityScheme: string]: SecuritySchemeObject | ReferenceObject };
+    links?: { [link: string]: LinkObject | ReferenceObject };
+    callbacks?: { [callback: string]: CallbackObject | ReferenceObject };
+    pathItems?: { [pathItem: string]: PathItemObject | ReferenceObject };
+    /** @since OAS 3.2 An object to hold reusable Media Type Objects. */
+    mediaTypes?: { [mediaType: string]: MediaTypeObject | ReferenceObject };
+}
+
+/**
+ * Rename it to Paths Object to be consistent with the spec
+ * See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#paths-object
+ */
+export interface PathsObject extends ISpecificationExtension {
+    // [path: string]: PathItemObject;
+    [path: string]: PathItemObject;
+}
+
+/**
+ * @deprecated
+ * Create a type alias for backward compatibility
+ */
+export type PathObject = PathsObject;
+
+export function getPath(
+    pathsObject: PathsObject | undefined,
+    path: string
+): PathItemObject | undefined {
+    if (SpecificationExtension.isValidExtension(path)) {
+        return undefined;
+    }
+    return pathsObject ? (pathsObject[path] as PathItemObject) : undefined;
+}
+
+export interface PathItemObject extends ISpecificationExtension {
+    $ref?: string;
+    summary?: string;
+    description?: string;
+    get?: OperationObject;
+    put?: OperationObject;
+    post?: OperationObject;
+    delete?: OperationObject;
+    options?: OperationObject;
+    head?: OperationObject;
+    patch?: OperationObject;
+    trace?: OperationObject;
+    /** @since OAS 3.2 A definition of a QUERY operation on this path. */
+    query?: OperationObject;
+    /**
+     * @since OAS 3.2 A map of additional operations on this path. The map key is the
+     * HTTP method with the capitalization to be sent in the request. MUST NOT contain
+     * an entry for a method that can be defined by a fixed field (e.g. no `POST`).
+     */
+    additionalOperations?: { [method: string]: OperationObject };
+    servers?: ServerObject[];
+    parameters?: (ParameterObject | ReferenceObject)[];
+}
+export interface OperationObject extends ISpecificationExtension {
+    tags?: string[];
+    summary?: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+    operationId?: string;
+    parameters?: (ParameterObject | ReferenceObject)[];
+    requestBody?: RequestBodyObject | ReferenceObject;
+    responses?: ResponsesObject;
+    callbacks?: CallbacksObject;
+    deprecated?: boolean;
+    security?: SecurityRequirementObject[];
+    servers?: ServerObject[];
+}
+export interface ExternalDocumentationObject extends ISpecificationExtension {
+    description?: string;
+    url: string;
+}
+
+/**
+ * The location of a parameter.
+ * Possible values are "query", "querystring", "header", "path" or "cookie".
+ * The "querystring" location is new in OAS 3.2.
+ * Specification:
+ * https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#parameter-locations
+ */
+export type ParameterLocation = 'query' | 'querystring' | 'header' | 'path' | 'cookie';
+
+/**
+ * The style of a parameter.
+ * Describes how the parameter value will be serialized.
+ * (serialization is not implemented yet)
+ * The "cookie" style is new in OAS 3.2.
+ * Specification:
+ * https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#style-values
+ */
+export type ParameterStyle =
+    | 'matrix'
+    | 'label'
+    | 'form'
+    | 'simple'
+    | 'spaceDelimited'
+    | 'pipeDelimited'
+    | 'deepObject'
+    | 'cookie';
+
+export interface BaseParameterObject extends ISpecificationExtension {
+    description?: string;
+    required?: boolean;
+    deprecated?: boolean;
+    /** @deprecated Use of this field is NOT RECOMMENDED in OAS 3.2 and is likely to be removed in a later revision. Valid only for `query` parameters. */
+    allowEmptyValue?: boolean;
+
+    style?: ParameterStyle; // "matrix" | "label" | "form" | ... | "deepObject" | "cookie";
+    explode?: boolean;
+    allowReserved?: boolean;
+    schema?: SchemaObject | ReferenceObject;
+    examples?: { [param: string]: ExampleObject | ReferenceObject };
+    example?: any;
+    content?: ContentObject;
+}
+
+export interface ParameterObject extends BaseParameterObject {
+    name: string;
+    in: ParameterLocation; // "query" | "querystring" | "header" | "path" | "cookie";
+}
+export interface RequestBodyObject extends ISpecificationExtension {
+    description?: string;
+    content: ContentObject;
+    required?: boolean;
+}
+export interface ContentObject {
+    // @since OAS 3.2 content map values may also be Reference Objects, e.g. referencing
+    // the new `components.mediaTypes` bucket. In 3.0/3.1 only Media Type Objects were allowed.
+    [mediatype: string]: MediaTypeObject | ReferenceObject;
+}
+export interface MediaTypeObject extends ISpecificationExtension {
+    /** A schema describing the complete content of the request, response, parameter, or header. */
+    schema?: SchemaObject | ReferenceObject;
+    /** @since OAS 3.2 A schema describing each item within a sequential (streaming) media type. */
+    itemSchema?: SchemaObject | ReferenceObject;
+    examples?: ExamplesObject;
+    example?: any;
+    /** A map between a property name and its encoding information. MUST NOT be present if `prefixEncoding` or `itemEncoding` are present. */
+    encoding?: EncodingObject;
+    /**
+     * @since OAS 3.2 An array of positional encoding information (analogous to JSON
+     * Schema `prefixItems`); `multipart` only. MUST NOT be present if `encoding` is present.
+     */
+    prefixEncoding?: EncodingPropertyObject[];
+    /**
+     * @since OAS 3.2 A single Encoding Object applied to all remaining array items
+     * (analogous to JSON Schema `items`); `multipart` only. MUST NOT be present if `encoding` is present.
+     */
+    itemEncoding?: EncodingPropertyObject;
+}
+export interface EncodingObject extends ISpecificationExtension {
+    // [property: string]: EncodingPropertyObject;
+    [property: string]: EncodingPropertyObject | any; // Hack for allowing ISpecificationExtension
+}
+export interface EncodingPropertyObject {
+    contentType?: string;
+    headers?: { [key: string]: HeaderObject | ReferenceObject };
+    style?: string;
+    explode?: boolean;
+    allowReserved?: boolean;
+    /** @since OAS 3.2 Nested encoding, applied in the same manner as the Media Type Object's `encoding`. */
+    encoding?: EncodingObject;
+    /** @since OAS 3.2 Nested positional encoding, applied in the same manner as the Media Type Object's `prefixEncoding`. */
+    prefixEncoding?: EncodingPropertyObject[];
+    /** @since OAS 3.2 Nested item encoding, applied in the same manner as the Media Type Object's `itemEncoding`. */
+    itemEncoding?: EncodingPropertyObject;
+    [key: string]: any; // (any) = Hack for allowing ISpecificationExtension
+}
+export interface ResponsesObject extends ISpecificationExtension {
+    default?: ResponseObject | ReferenceObject;
+
+    // [statuscode: string]: ResponseObject | ReferenceObject;
+    [statuscode: string]: ResponseObject | ReferenceObject | any; // (any) = Hack for allowing ISpecificationExtension
+}
+export interface ResponseObject extends ISpecificationExtension {
+    /** @since OAS 3.2 A short summary of the meaning of the response. */
+    summary?: string;
+    /**
+     * A description of the response.
+     * @since OAS 3.2 this field is optional (it was REQUIRED in OAS 3.0/3.1).
+     */
+    description?: string;
+    headers?: HeadersObject;
+    content?: ContentObject;
+    links?: LinksObject;
+}
+export interface CallbacksObject extends ISpecificationExtension {
+    // [name: string]: CallbackObject | ReferenceObject;
+    [name: string]: CallbackObject | ReferenceObject | any; // Hack for allowing ISpecificationExtension
+}
+export interface CallbackObject extends ISpecificationExtension {
+    // [name: string]: PathItemObject;
+    [name: string]: PathItemObject | any; // Hack for allowing ISpecificationExtension
+}
+export interface HeadersObject {
+    [name: string]: HeaderObject | ReferenceObject;
+}
+export interface ExampleObject {
+    summary?: string;
+    description?: string;
+    /**
+     * @since OAS 3.2 An example of the data structure that MUST be valid according to the
+     * relevant Schema Object. If present, `value` MUST be absent.
+     */
+    dataValue?: any;
+    /**
+     * @since OAS 3.2 An example of the serialized form of the value. If present, `value`
+     * and `externalValue` MUST be absent. SHOULD NOT be used when the serialization format is JSON.
+     */
+    serializedValue?: string;
+    /** @deprecated For non-JSON serialization targets, use `dataValue` and/or `serializedValue`. Mutually exclusive with `externalValue`. */
+    value?: any;
+    externalValue?: string;
+    [property: string]: any; // Hack for allowing ISpecificationExtension
+}
+export interface LinksObject {
+    [name: string]: LinkObject | ReferenceObject;
+}
+export interface LinkObject extends ISpecificationExtension {
+    operationRef?: string;
+    operationId?: string;
+    parameters?: LinkParametersObject;
+    requestBody?: any | string;
+    description?: string;
+    server?: ServerObject;
+    [property: string]: any; // Hack for allowing ISpecificationExtension
+}
+export interface LinkParametersObject {
+    [name: string]: any | string;
+}
+
+export interface HeaderObject extends BaseParameterObject {
+    $ref?: string;
+}
+export interface TagObject extends ISpecificationExtension {
+    name: string;
+    /** @since OAS 3.2 A short summary of the tag, used for display purposes. */
+    summary?: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+    /** @since OAS 3.2 The `name` of a tag that this tag is nested under. The named tag MUST exist and circular references MUST NOT be used. */
+    parent?: string;
+    /**
+     * @since OAS 3.2 A machine-readable string to categorize the tag. Any string value
+     * can be used; common values are `nav`, `badge`, `audience`. A registry of common
+     * values is at https://spec.openapis.org/registry/tag-kind/.
+     */
+    kind?: string;
+    [extension: string]: any; // Hack for allowing ISpecificationExtension
+}
+export interface ExamplesObject {
+    [name: string]: ExampleObject | ReferenceObject;
+}
+
+export interface ReferenceObject {
+    $ref: string;
+    summary?: string;
+    description?: string;
+}
+
+/**
+ * A type guard to check if the given value is a `ReferenceObject`.
+ * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
+ *
+ * @param obj The value to check.
+ */
+export function isReferenceObject(obj: any): obj is ReferenceObject {
+    return Object.prototype.hasOwnProperty.call(obj, '$ref');
+}
+
+export type SchemaObjectType =
+    | 'integer'
+    | 'number'
+    | 'string'
+    | 'boolean'
+    | 'object'
+    | 'null'
+    | 'array';
+
+export type SchemaObject = SchemaObjectValue | boolean;
+
+export interface SchemaObjectValue extends ISpecificationExtension {
+    [keyword: string]: any;
+    $ref?: string;
+    $schema?: string;
+    $id?: string;
+    $anchor?: string;
+    $dynamicRef?: string;
+    $dynamicAnchor?: string;
+    $defs?: { [schema: string]: SchemaObject | ReferenceObject };
+    discriminator?: DiscriminatorObject;
+    readOnly?: boolean;
+    writeOnly?: boolean;
+    xml?: XmlObject;
+    externalDocs?: ExternalDocumentationObject;
+    /** @deprecated use examples instead */
+    example?: any;
+    examples?: any[];
+    deprecated?: boolean;
+
+    type?: SchemaObjectType | SchemaObjectType[];
+    format?:
+        | 'int32'
+        | 'int64'
+        | 'float'
+        | 'double'
+        | 'byte'
+        | 'binary'
+        | 'date'
+        | 'date-time'
+        | 'password'
+        | string;
+    allOf?: (SchemaObject | ReferenceObject)[];
+    oneOf?: (SchemaObject | ReferenceObject)[];
+    anyOf?: (SchemaObject | ReferenceObject)[];
+    not?: SchemaObject | ReferenceObject;
+    items?: SchemaObject | ReferenceObject;
+    contains?: SchemaObject | ReferenceObject;
+    properties?: { [propertyName: string]: SchemaObject | ReferenceObject };
+    additionalProperties?: SchemaObject | ReferenceObject | boolean;
+    propertyNames?: SchemaObject | ReferenceObject;
+    patternProperties?: { [propertyName: string]: SchemaObject | ReferenceObject };
+    dependentSchemas?: { [propertyName: string]: SchemaObject | ReferenceObject };
+    dependentRequired?: { [propertyName: string]: string[] };
+    if?: SchemaObject | ReferenceObject;
+    then?: SchemaObject | ReferenceObject;
+    else?: SchemaObject | ReferenceObject;
+    unevaluatedItems?: SchemaObject | ReferenceObject | boolean;
+    unevaluatedProperties?: SchemaObject | ReferenceObject | boolean;
+    description?: string;
+    default?: any;
+
+    title?: string;
+    multipleOf?: number;
+    maximum?: number;
+    const?: any;
+    /** @desc In OpenAPI 3.1: number */
+    exclusiveMaximum?: number;
+    minimum?: number;
+    /** @desc In OpenAPI 3.1: number */
+    exclusiveMinimum?: number;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    required?: string[];
+    enum?: any[];
+    prefixItems?: (SchemaObject | ReferenceObject)[];
+    contentSchema?: SchemaObject | ReferenceObject;
+    /**
+     * @desc JSON Schema compliant Content-Type, optional when specified as a key of ContentObject
+     * @example image/png
+     */
+    contentMediaType?: string;
+    /**
+     * @desc Specifies the Content-Encoding for the schema, supports all encodings from RFC4648, and "quoted-printable" from RFC2045
+     * @override format
+     * @see https://datatracker.ietf.org/doc/html/rfc4648
+     * @see https://datatracker.ietf.org/doc/html/rfc2045#section-6.7
+     * @example base64
+     */
+    contentEncoding?: string;
+}
+
+/**
+ * A type guard to check if the given object is a `SchemaObject`.
+ * Useful to distinguish from `ReferenceObject` values that can be used
+ * in most places where `SchemaObject` is allowed.
+ *
+ * See https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-guards-and-differentiating-types
+ *
+ * @param schema The value to check.
+ */
+export function isSchemaObject(schema: SchemaObject | ReferenceObject): schema is SchemaObject {
+    return !Object.prototype.hasOwnProperty.call(schema, '$ref');
+}
+
+export interface SchemasObject {
+    [schema: string]: SchemaObject;
+}
+
+export interface DiscriminatorObject {
+    propertyName: string;
+    mapping?: { [key: string]: string };
+    /**
+     * @since OAS 3.2 The schema name or URI reference to a schema expected to validate the
+     * model when the discriminating property is missing or holds an unmapped value. REQUIRED
+     * when the discriminating property is defined as optional.
+     */
+    defaultMapping?: string;
+}
+
+/**
+ * The XML node type of a Schema Object, new in OAS 3.2.
+ * `none` means the schema produces no node of its own.
+ */
+export type XmlNodeType = 'element' | 'attribute' | 'text' | 'cdata' | 'none';
+
+export interface XmlObject extends ISpecificationExtension {
+    /**
+     * @since OAS 3.2 One of `element`, `attribute`, `text`, `cdata`, or `none`. Default is
+     * `none` if `$ref`, `$dynamicRef`, or `type: "array"` is present in the containing
+     * Schema Object, and `element` otherwise. Supersedes the `attribute`/`wrapped` booleans.
+     */
+    nodeType?: XmlNodeType;
+    name?: string;
+    namespace?: string;
+    prefix?: string;
+    /** @deprecated Use `nodeType: "attribute"` instead. If `nodeType` is present, this field MUST NOT be present. */
+    attribute?: boolean;
+    /** @deprecated Use `nodeType: "element"` instead. If `nodeType` is present, this field MUST NOT be present. */
+    wrapped?: boolean;
+}
+export type SecuritySchemeType = 'apiKey' | 'http' | 'mutualTLS' | 'oauth2' | 'openIdConnect';
+
+export interface SecuritySchemeObject extends ISpecificationExtension {
+    type: SecuritySchemeType;
+    description?: string;
+    name?: string; // required only for apiKey
+    in?: string; // required only for apiKey
+    scheme?: string; // required only for http
+    bearerFormat?: string;
+    flows?: OAuthFlowsObject; // required only for oauth2
+    openIdConnectUrl?: string; // required only for openIdConnect
+    /** @since OAS 3.2 URL to the OAuth2 Authorization Server Metadata (RFC8414). Used with `type: oauth2`. */
+    oauth2MetadataUrl?: string;
+    /** @since OAS 3.2 Declares this security scheme to be deprecated. Default value is `false`. */
+    deprecated?: boolean;
+}
+export interface OAuthFlowsObject extends ISpecificationExtension {
+    implicit?: OAuthFlowObject;
+    password?: OAuthFlowObject;
+    clientCredentials?: OAuthFlowObject;
+    authorizationCode?: OAuthFlowObject;
+    /** @since OAS 3.2 Configuration for the OAuth 2.0 Device Authorization flow (RFC8628). */
+    deviceAuthorization?: OAuthFlowObject;
+}
+export interface OAuthFlowObject extends ISpecificationExtension {
+    authorizationUrl?: string;
+    /** @since OAS 3.2 The device authorization endpoint URL (RFC8628 §3.1). REQUIRED for the `deviceAuthorization` flow. */
+    deviceAuthorizationUrl?: string;
+    tokenUrl?: string;
+    refreshUrl?: string;
+    scopes: ScopesObject;
+}
+export interface ScopesObject extends ISpecificationExtension {
+    [scope: string]: any; // Hack for allowing ISpecificationExtension
+}
+export interface SecurityRequirementObject {
+    [name: string]: string[];
+}

--- a/src/oas32.ts
+++ b/src/oas32.ts
@@ -1,0 +1,4 @@
+export * from './dsl/openapi-builder32';
+export * from './model/openapi32';
+export { Server, ServerVariable } from './model/server';
+export type { IExtensionName, IExtensionType, ISpecificationExtension } from './model/specification-extension';

--- a/test/index.cjs
+++ b/test/index.cjs
@@ -1,8 +1,8 @@
 const assert = require('node:assert');
-const { oas31 } = require('openapi3-ts');
-const { OpenApiBuilder } = require('openapi3-ts/oas31');
+const { oas32 } = require('openapi3-ts');
+const { OpenApiBuilder } = require('openapi3-ts/oas32');
 
-const builder1 = new oas31.OpenApiBuilder();
+const builder1 = new oas32.OpenApiBuilder();
 assert.ok(typeof builder1.rootDoc === 'object');
 const builder2 = new OpenApiBuilder();
 assert.ok(typeof builder2.rootDoc === 'object');

--- a/test/index.cts
+++ b/test/index.cts
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
-import { oas31 } from 'openapi3-ts';
-import { OpenApiBuilder } from 'openapi3-ts/oas31';
+import { oas32 } from 'openapi3-ts';
+import { OpenApiBuilder } from 'openapi3-ts/oas32';
 
-const builder1 = new oas31.OpenApiBuilder();
+const builder1 = new oas32.OpenApiBuilder();
 assert.ok(typeof builder1.rootDoc === 'object');
 const builder2 = new OpenApiBuilder();
 assert.ok(typeof builder2.rootDoc === 'object');

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
-import { oas31 } from 'openapi3-ts';
-import { OpenApiBuilder } from 'openapi3-ts/oas31';
+import { oas32 } from 'openapi3-ts';
+import { OpenApiBuilder } from 'openapi3-ts/oas32';
 
-const builder1 = new oas31.OpenApiBuilder();
+const builder1 = new oas32.OpenApiBuilder();
 assert.ok(typeof builder1.rootDoc === 'object');
 const builder2 = new OpenApiBuilder();
 assert.ok(typeof builder2.rootDoc === 'object');

--- a/test/index.mts
+++ b/test/index.mts
@@ -1,8 +1,8 @@
 import assert from 'node:assert';
-import { oas31 } from 'openapi3-ts';
-import { OpenApiBuilder } from 'openapi3-ts/oas31';
+import { oas32 } from 'openapi3-ts';
+import { OpenApiBuilder } from 'openapi3-ts/oas32';
 
-const builder1 = new oas31.OpenApiBuilder();
+const builder1 = new oas32.OpenApiBuilder();
 assert.ok(typeof builder1.rootDoc === 'object');
 const builder2 = new OpenApiBuilder();
 assert.ok(typeof builder2.rootDoc === 'object');

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -8,7 +8,8 @@ export default defineConfig({
             entry: {
                 index: resolve(__dirname, 'src/index.ts'),
                 oas30: resolve(__dirname, 'src/oas30.ts'),
-                oas31: resolve(__dirname, 'src/oas31.ts')
+                oas31: resolve(__dirname, 'src/oas31.ts'),
+                oas32: resolve(__dirname, 'src/oas32.ts')
             },
             name: 'OpenApi3TS'
         },


### PR DESCRIPTION
Adds OAS 3.2 as a new `oas32` module alongside the existing 3.0/3.1 ones, with the same layout (model, builder, barrel, subpath export, d.ts shim). 3.0 and 3.1 are untouched.

3.2 didn't change the JSON Schema dialect (still 2020-12), so it's mostly new document-level fields: streaming `itemSchema`/`itemEncoding`/`prefixEncoding`, the `mediaTypes` components bucket, `query` and `additionalOperations` on path items, the `querystring` param location, XML `nodeType`, the OAuth device flow, `$self`, and so on.

Couple of notes:
- SchemaObject is typed a bit more completely than the 3.1 one (boolean schemas, the 2020-12 `unevaluated*` keywords). Same dialect, just filling gaps.
- I included a few fields that were already valid in 3.1 but missing from the 3.1 model (`jsonSchemaDialect`, `Info.summary`, `mutualTLS`) so the 3.2 types are complete. Can split those into a separate 3.1 PR if you'd rather keep this scoped.

Closes #157.
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md
